### PR TITLE
Test code examples in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -825,6 +825,7 @@ template:
   - {$eval: 'lstrip("  room  ")'}
   - {$eval: 'rstrip("  room  ")'}
   - {$eval: 'strip("  room  ")'}
+  - {$eval: 'split("left:right", ":")'}	
 context: {}
 result:
   - "fools!"
@@ -833,6 +834,7 @@ result:
   - "room  "
   - "  room"
   - room
+  - [left, right]
 ```
 
 #### Arrays

--- a/README.md
+++ b/README.md
@@ -436,10 +436,10 @@ result: ["ten"]
 ```
 
 ```yaml
-template: {$match: {"x == 10 || x == 20": "tens", "x == 10": "ten"}}
+# $sort the otherwise arbitrarily ordered results
+template: {$sort:{$match: {"x == 10 || x == 20": "tens", "x == 10": "ten"}}}
 context: {x: 10}
 result: ["ten", "tens"]
-# another possible result: ["tens", "ten"]
 ```
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -825,7 +825,7 @@ template:
   - {$eval: 'lstrip("  room  ")'}
   - {$eval: 'rstrip("  room  ")'}
   - {$eval: 'strip("  room  ")'}
-  - {$eval: 'split("left:right", ":")'}	
+  - {$eval: 'split("left:right", ":")'}
 context: {}
 result:
   - "fools!"

--- a/README.md
+++ b/README.md
@@ -437,7 +437,7 @@ result: ["ten"]
 
 ```yaml
 # $sort the otherwise arbitrarily ordered results
-template: {$sort:{$match: {"x == 10 || x == 20": "tens", "x == 10": "ten"}}}
+template: {$sort: {$match: {"x == 10 || x == 20": "tens", "x == 10": "ten"}}}
 context: {x: 10}
 result: ["ten", "tens"]
 ```

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ structure.
 ```yaml
 template: {$json: [a, b, {$eval: 'a+b'}, 4]}
 context:  {a: 1, b: 2}
-result:   '["a", "b", 3, 4]'
+result:   '["a","b",3,4]'
 ```
 
 ### `$if` - `then` - `else`
@@ -321,7 +321,7 @@ example:
 ```yaml
 template: {$fromNow: '2 days 1 hour'}
 context:  {}
-result:   '2017-01-19T16:27:20.974Z'
+result:   '2017-01-21T17:27:20.974Z'
 ```
 
 ```yaml
@@ -438,9 +438,10 @@ result: ["ten"]
 ```yaml
 template: {$match: {"x == 10 || x == 20": "tens", "x == 10": "ten"}}
 context: {x: 10}
-one possible result: ["tens", "ten"]
-another possible result: ["ten", "tens"]
+result: ["ten", "tens"]
+# another possible result: ["tens", "ten"]
 ```
+
 ```yaml
 template: {$match: {"x < 10": "tens"}}
 context: {x: 10}
@@ -484,7 +485,7 @@ result: {a: 1}
 ```
 
 ```yaml
-template: [1, b: {$switch: {"x == 1": 2, "x == 10": 3}}]
+template: [1, {$switch: {"x == 2": 2, "x == 10": 3}}]
 context: {x: 2}
 result: [1, 2]
 ```
@@ -712,7 +713,7 @@ does not have `prop`, while `obj['prop']` will evaluate to `null`.
 template: {$eval: 'v.a + v["b"]'}
 context: {v: {a: 'apple', b: 'bananna', c: 'carrot'}}
 result: 'applebananna'
-````
+```
 
 ### Indexing and Slicing
 
@@ -783,9 +784,9 @@ template:
   - {$eval: 'fromNow("1 minute", "2017-01-19T16:27:20.974Z")'}
 context: {}
 result:
-  - '2017-01-19T16:27:20.974Z',
-  - '2017-01-19T16:28:20.974Z',
-  - '2017-01-19T16:28:20.974Z',
+  - '2017-01-19T16:27:20.974Z'
+  - '2017-01-19T16:28:20.974Z'
+  - '2017-01-19T16:28:20.974Z'
 ```
 
 #### Math
@@ -824,7 +825,6 @@ template:
   - {$eval: 'lstrip("  room  ")'}
   - {$eval: 'rstrip("  room  ")'}
   - {$eval: 'strip("  room  ")'}
-  - {$eval: 'split("left:right", ":")'}
 context: {}
 result:
   - "fools!"
@@ -833,21 +833,18 @@ result:
   - "room  "
   - "  room"
   - room
-  - [left, right]
 ```
 
 #### Arrays
 
 ```yaml
 template:
-  # Joins arrays of strings and numbers (including mixed types) into a string using a separator, 
-  # which can also be either string or number.
   - {$eval: 'join(["carpe", "diem"], " ")'}
-  - {$eval: 'join([1, 3], 2)}'}
+  - {$eval: 'join([1, 3], 2)'}
 context: {}
 result:
   - carpe diem
-  - "123"
+  - '123'
 ```
 
 #### Context
@@ -887,8 +884,8 @@ result:
  - array
  - object
  - function
- - null 
- - ''    # .. which interpolates to an empty string
+ - 'null'
+ - 'null'    # .. which interpolates to an empty string
 ```
 
 #### Length

--- a/test/doc_code_test.js
+++ b/test/doc_code_test.js
@@ -1,0 +1,56 @@
+const fs = require("fs");
+const path = require("path");
+
+const yaml = require("js-yaml");
+const assume = require("assume");
+const assert = require("assert");
+const tk = require("timekeeper");
+const jsone = require("../src");
+
+const readme = fs.readFileSync(path.join(__dirname, "../README.md"), {
+  encoding: "utf8",
+});
+const TEST_DATE = new Date("2017-01-19T16:27:20.974Z");
+
+suite("docs code examples", () => {
+  const yamlCodeBlocksRegex = /(```yaml)([a-z]*\n[\s\S]*?\n)(```)/gm;
+  let matches;
+  const foundSpecs = [];
+  while ((matches = yamlCodeBlocksRegex.exec(readme)) !== null) {
+    // This is necessary to avoid infinite loops with zero-width matches
+    if (matches.index === yamlCodeBlocksRegex.lastIndex) {
+      yamlCodeBlocksRegex.lastIndex++;
+    }
+
+    const [, , codeblock] = matches;
+    foundSpecs.push(codeblock);
+  }
+
+  const specs = yaml.loadAll(foundSpecs.join("---\n"));
+
+  before(() => tk.freeze(TEST_DATE));
+  after(() => tk.reset());
+
+  specs
+    .filter((spec) => spec && spec.template)
+    .forEach((spec, i) => {
+      test(JSON.stringify(spec.template), () => {
+        let result;
+        try {
+          result = jsone(spec.template, spec.context);
+        } catch (err) {
+          if (!spec.error) {
+            throw err;
+          }
+          if (spec.error === true) {
+            // no specific expectation
+            return;
+          }
+          assume(err.toString()).eql(spec.error);
+          return;
+        }
+        assert(!spec.error, "Expected an error");
+        assume(result).eql(spec.result);
+      });
+    });
+});

--- a/test/doc_code_test.js
+++ b/test/doc_code_test.js
@@ -16,6 +16,7 @@ suite("docs code examples", () => {
   const yamlCodeBlocksRegex = /(```yaml)([a-z]*\n[\s\S]*?\n)(```)/gm;
   let matches;
   const foundSpecs = [];
+  
   while ((matches = yamlCodeBlocksRegex.exec(readme)) !== null) {
     // This is necessary to avoid infinite loops with zero-width matches
     if (matches.index === yamlCodeBlocksRegex.lastIndex) {
@@ -33,7 +34,7 @@ suite("docs code examples", () => {
 
   specs
     .filter((spec) => spec && spec.template)
-    .forEach((spec, i) => {
+    .forEach((spec) => {
       test(JSON.stringify(spec.template), () => {
         let result;
         try {


### PR DESCRIPTION
This PR is extracting the code block examples in the `readme.md` and integrate them into the javascript test suite, potentially causing it to break in case of errors prior to releasing.

A couple of decision had to be made which can be discussed:

1. **Parsing**
    I had several attempts to extract the tests from the `readme` markdown file.
    I wanted to extract the markdown title closest to the test and put a test title like `$map example 1` etc. Finally, I went with a much simpler solution which parses the markdown with a simple regex to gather the yaml code blocks and makes the stringified template the title, which is a great help when there are errors as you can easily find the right spot.

   **Tries worth mentioning:** 
     - using commonmark to parse the tree and use a walker to generate spec entries
     - using `sed` to generate a static yml file as the current specification file

2. **Using the javascript mocha test only**
    The reasoning behind this is that it's enough to test once as the various language implementation should be similar.

3. **Readme postmortem fixes**
    I fixed the errors that popped up in the readme examples. Some were trivial, some maybe not so. Please have a very deep look.

# Checklist

Before submitting a pull request, please check the following:

* [x] All tests pass for you on your machine for all implementations (all implementations must behave identically)
* [x] New tests have been added for any new functionality or to prevent regressions of a bugfix
* [x] Added a short description of the change to `newsfragments/$issue.bugfix` (for fixes) or `.feature` (for new features) or `.doc` (for documentation-only changes)
