### PR TITLE
`$default` arm  in `$switch` operator

### DIFF
--- a/docs/src/operators.md
+++ b/docs/src/operators.md
@@ -257,10 +257,11 @@ The `$switch` operator behaves like a combination of the `$if` and
 in which every key is a string expression(s), where at most *one* must
 evaluate to `true` and the remaining to `false` based on the context.
 The result will be the value corresponding to the key that were
-evaluated to `true`.
+evaluated to `true` or optionally the fallback `$default` value.
 
-If there are no matches, the result is either null or if used within an
-object or array, omitted from the parent object.
+If there are no matches, and no `$default` fallback is provided, the
+result is either null or if used within an object or array, omitted
+from the parent object.
 
 ```yaml,json-e
 template: {$switch: {"x == 10": "ten", "x == 20": "twenty"}}
@@ -296,6 +297,12 @@ result: [1, 2]
 template: [0, {$switch: {'cond > 3': 2, 'cond == 5': 3}}]
 context:  {cond: 3}
 result:   [0]
+```
+
+```yaml,json-e
+template: [0, {$switch: {'cond > 3': 2, 'cond == 5': 3, $default: 4}}]
+context:  {cond: 1}
+result:   [4]
 ```
 
 ## `$merge`

--- a/internal/jsone.go
+++ b/internal/jsone.go
@@ -715,7 +715,9 @@ var operators = map[string]operator{
 
 		conditions := make([]string, 0, len(match))
 		for condition := range match {
-			conditions = append(conditions, condition)
+			if (condition != "$default") {
+				conditions = append(conditions, condition)
+			}
 		}
 
 		result := make([]interface{}, 0, len(match))
@@ -747,6 +749,18 @@ var operators = map[string]operator{
 				Message:  "$switch can only have one truthy condition",
 				Template: template,
 			}
+		}
+
+		if len(result) == 0 && match["$default"] != nil {
+			value := match["$default"]
+			r, err := render(value, context)
+			if err != nil {
+				return nil, TemplateError{
+					Message:  err.Error(),
+					Template: template,
+				}
+			}
+			result = append(result, r)
 		}
 
 		if len(result) == 0 {

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -239,7 +239,7 @@ operators.$match = (template, context) => {
 };
 
 operators.$switch = (template, context) => {
-  checkUndefinedProperties(template, ['\\$switch']);
+  checkUndefinedProperties(template, [ '\\$switch' ]);
 
   if (!isObject(template['$switch'])) {
     throw new TemplateError('$switch can evaluate objects only');
@@ -248,7 +248,7 @@ operators.$switch = (template, context) => {
   let result = [];
   const conditions = template['$switch'];
 
-  for (let condition of Object.keys(conditions)) {
+  for (let condition of Object.keys(conditions).filter(k => k !== '$default').sort()) {
     if (isTruthy(parse(condition, context))) {
       result.push(render(conditions[condition], context));
     }
@@ -256,6 +256,10 @@ operators.$switch = (template, context) => {
 
   if (result.length > 1) {
     throw new TemplateError('$switch can only have one truthy condition');
+  }
+
+  if (result.length === 0 && conditions[ '$default' ]) {
+    result.push(render(conditions[ '$default' ], context));
   }
 
   return result.length > 0 ? result[0] : deleteMarker;

--- a/py/jsone/newsfragments/455.feature
+++ b/py/jsone/newsfragments/455.feature
@@ -1,0 +1,1 @@
+Added a $default case to the switch operator

--- a/py/jsone/render.py
+++ b/py/jsone/render.py
@@ -283,11 +283,15 @@ def switch(template, context):
 
     result = []
     for condition in template['$switch']:
-        if parse(condition, context):
+        if not condition == '$default' and parse(condition, context):
             result.append(renderValue(template['$switch'][condition], context))
 
     if len(result) > 1:
         raise TemplateError("$switch can only have one truthy condition")
+
+    if len(result) == 0:
+        if '$default' in template['$switch']:
+            result.append(renderValue(template['$switch']['$default'], context))
 
     return result[0] if len(result) > 0 else DeleteMarker
 

--- a/rs/src/render.rs
+++ b/rs/src/render.rs
@@ -479,7 +479,7 @@ fn switch_operator(
     object: &Object,
     context: &Context,
 ) -> Result<Value> {
-    check_operator_properties(operator, object, |_| false)?;    
+    check_operator_properties(operator, object, |_| false)?;
     if let Value::Object(obj) = _render(value, context)? {
         if let Ok(Value::Array(mut matches)) = get_matching_conditions(obj, context, true) {
             if let Value::Object(ref o) = value {

--- a/specification.yml
+++ b/specification.yml
@@ -1,5 +1,5 @@
 ################################################################################
-# ### Specificaiton for json-e
+# ### Specification for json-e
 # This document specifies the json-e template language through a series of
 # test cases on the form: `{title, context, template, result, error, panic}`
 # where `jsone.render(template, context) = result` and title is short name
@@ -1051,7 +1051,17 @@ title:    $switch, value that also needs evaluation
 context:  {cond: 3, ifcond: false}
 template: {$switch: {'cond == 3': {$if: 'ifcond', then: "t", else: "f"}}}
 result:   "f"
-################################################################################
+---
+title:    $switch, fallback to $default
+context:  {cond: 4}
+template: {$switch: {'cond == 3': 1, $default: 'fallback'}}
+result:   "fallback"
+---
+title:    $switch, $default value that also needs evaluation
+context:  {cond: 4, ifcond: false}
+template: {$switch: {'cond == 3': 1, $default: {$if: 'ifcond', then: "t", else: "f"}}}
+result:   "f"
+###############################################################################
 ---
 section:  $merge
 ---

--- a/specification.yml
+++ b/specification.yml
@@ -1061,6 +1061,11 @@ title:    $switch, $default value that also needs evaluation
 context:  {cond: 4, ifcond: false}
 template: {$switch: {'cond == 3': 1, $default: {$if: 'ifcond', then: "t", else: "f"}}}
 result:   "f"
+---
+title:    $switch, $default with 1 match in object
+context:  {cond: 3}
+template: {$switch: {'cond == 3': 1, $default: 'fallback'}}
+result:   1
 ###############################################################################
 ---
 section:  $merge


### PR DESCRIPTION
This change introduces a `$default` fallback case in the `$switch` operator as suggested in #455.

**NB** I'm not fluent in RUST so there might be some street smarts that can be applied! Please suggest, I promise you wont hurt my feelings!

# Checklist

Before submitting a pull request, please check the following:

* [X] All tests pass for you on your machine for all implementations (all implementations must behave identically)
* [X] New tests have been added for any new functionality or to prevent regressions of a bugfix
* [X] Added a short description of the change to `newsfragments/$issue.bugfix` (for fixes) or `.feature` (for new features) or `.doc` (for documentation-only changes)
