### PR TITLE
Actually really run Rust CI

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -130,7 +130,7 @@ tasks:
               cd rs/ &&
               cargo test
         - image: 'rust:latest'
-          name: rust tests
+          name: mdbook tests
           command:
             - /bin/bash
             - '-c'

--- a/rs/src/builtins.rs
+++ b/rs/src/builtins.rs
@@ -175,19 +175,10 @@ fn number_builtin(_context: &Context, args: &[Value]) -> Result<Value> {
     }
     let v = &args[0];
     let num: f64 = match v {
-        Value::Null => 0.0,
         Value::String(s) => match s.parse() {
             Ok(num) => num,
             Err(_) => return Err(interpreter_error!("string can't be converted to number")),
         },
-        Value::Number(num) => *num,
-        Value::Bool(b) => {
-            if *b {
-                1.0
-            } else {
-                0.0
-            }
-        }
         _ => return Err(interpreter_error!("invalid arguments to builtin: number")),
     };
     Ok(Value::Number(num))


### PR DESCRIPTION
The fix to CI was simple -- it was just a collision of test names, which appeared to GitHub as the same check.

The fix to the failing tests was also simple.