### PR TITLE
Fix rust specification.yml rebuild logic

### DIFF
--- a/rs/build.rs
+++ b/rs/build.rs
@@ -10,12 +10,18 @@ use yaml_rust::{Yaml, YamlLoader};
 
 fn main() {
     // request to be re-run whenever ../specification.yml changes
-    println!("cargo:rerun-if-changed=../specification.yml");
+    let dev_path = std::path::Path::new("../specification.yml");
+    let crate_release_path = std::path::Path::new("specification.yml");
+    let spec_path = if dev_path.exists() {
+        dev_path
+    } else {
+        crate_release_path
+    };
+    println!("cargo:rerun-if-changed={}", spec_path.to_string_lossy());
 
     // read ../specification.yml, falling back to a copy in this directory
     // for builds from a crate
-    let spec = read_to_string("../specification.yml")
-        .unwrap_or_else(|_| read_to_string("./specification.yml").unwrap());
+    let spec = read_to_string(spec_path).unwrap();
     let spec = YamlLoader::load_from_str(&spec).unwrap();
 
     let out_dir = env::var("OUT_DIR").unwrap();


### PR DESCRIPTION
Cargo always rebuilds this crate right now since ```cargo:rerun-if-changed=PATH``` is pointing to a nonexistent file in the crate distribution. Fix is to better detect the location of ```specification.yml```

To reproduce this issue you can grab the crate from crates.io, extract it, and run ```cargo check``` repeatedly.  Another way to reproduce this issue is to temporarily move ```specification.yml``` from the root of this repo to the ```rs``` folder and run ```cargo check``` repeatedly.

See https://github.com/rust-lang/cargo/issues/6003 which proposes making this type of thing a warning in cargo.

# Checklist

Before submitting a pull request, please check the following:

* [ ] All tests pass for you on your machine for all implementations (all implementations must behave identically)
* [ ] New tests have been added for any new functionality or to prevent regressions of a bugfix
* [ ] Added a short description of the change to `newsfragments/$issue.bugfix` (for fixes) or `.feature` (for new features) or `.doc` (for documentation-only changes)
