### PR TITLE
docs: handle arbitrary newline placement in yaml

### DIFF
--- a/docs/jsone.js
+++ b/docs/jsone.js
@@ -134,9 +134,23 @@ const playground_block = (template, context) => {
 const remove_yaml_key = (key, yaml) => {
   const nl = yaml.indexOf('\n');
   if (nl != -1) {
-    const indented = yaml.slice(nl+1).split('\n');
-    const indent = /^ */.exec(indented[0])[0].length;
-    const dedented = indented.map(line => line.slice(indent));
+    const match = RegExp(`(^${key}: *)([\\s\\S]*)`).exec(yaml);
+    const rm_key = match[1];
+    const value = match[2];
+    const lines = value.split('\n');
+
+    let dedented = [];
+    if (lines[0] == "" && lines.length > 0) {
+      // Value started on a new line after the key, so align to the next line.
+      const first_line_indent = /^ */.exec(lines[1])[0].length;
+      for (let i = 1; i < lines.length; i++) {
+        dedented.push(lines[i].slice(first_line_indent));
+      }
+    } else {
+      // Value starts on this line and may continue on the next line
+      dedented = lines
+    }
+
     return dedented.join('\n');
   } else {
     return new RegExp(`^${key}: *(.*)`).exec(yaml)[1];

--- a/py/jsone/newsfragments/461.bugfix
+++ b/py/jsone/newsfragments/461.bugfix
@@ -1,0 +1,1 @@
+Fixed a bug that caused some examples in documentation not to be rendered on json-e.js.org


### PR DESCRIPTION
Previously some documentation was not being rendered properly on json-e.js.org because of assumptions about where newlines would be in template/context/result examples. This change adds better handling for multi line docs examples.

$let docs before:
![Screenshot from 2023-04-06 17-59-03](https://user-images.githubusercontent.com/3724288/230519425-07d807dd-47ce-4126-a291-472ed7a421bc.png)

$let docs after:
![Screenshot from 2023-04-06 17-59-17](https://user-images.githubusercontent.com/3724288/230519436-da0af28e-b07a-4710-8715-647758dbdb87.png)

fixes #461

# Checklist

Before submitting a pull request, please check the following:

* [ ] All tests pass for you on your machine for all implementations (all implementations must behave identically)
 - There aren't any tests for this part of the docs. Attached screenshots of the docs with the change.
* [ ] New tests have been added for any new functionality or to prevent regressions of a bugfix
* [ ] Added a short description of the change to `newsfragments/$issue.bugfix` (for fixes) or `.feature` (for new features) or `.doc` (for documentation-only changes)

