### PR TITLE
Upgrade to nom 7

### DIFF
--- a/py/jsone/newsfragments/462.bugfix
+++ b/py/jsone/newsfragments/462.bugfix
@@ -1,0 +1,1 @@
+Upgraded Rust parser-builder `nom` to major version 7.

--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -9,40 +9,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee10e43ae4a853c0a3591d4e2ada1719e553be18199d9da9d4a83f5927c2f5c7"
 
 [[package]]
-name = "arrayvec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
-
-[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitvec"
-version = "0.19.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55f93d0ef3363c364d5976646a38f04cf67cfe1d4c8d160cdea02cab2c116b33"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
-
-[[package]]
-name = "cfg-if"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
@@ -56,12 +26,6 @@ dependencies = [
  "time",
  "winapi",
 ]
-
-[[package]]
-name = "funty"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "itoa"
@@ -89,19 +53,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
-name = "lexical-core"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
-dependencies = [
- "arrayvec",
- "bitflags",
- "cfg-if",
- "ryu",
- "static_assertions",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -120,16 +71,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
-name = "nom"
-version = "6.2.1"
+name = "minimal-lexical"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c5c51b9083a3c620fa67a2a635d1ce7d95b897e957d6b28ff9a5da960a103a6"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
- "bitvec",
- "funty",
- "lexical-core",
  "memchr",
- "version_check",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -170,12 +124,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "radium"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
-
-[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -199,12 +147,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
 name = "syn"
 version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -214,12 +156,6 @@ dependencies = [
  "quote",
  "unicode-xid",
 ]
-
-[[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "thiserror"
@@ -259,12 +195,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
-name = "version_check"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
-
-[[package]]
 name = "wasi"
 version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -291,12 +221,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "wyz"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "yaml-rust"

--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -27,6 +27,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitvec"
+version = "0.19.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55f93d0ef3363c364d5976646a38f04cf67cfe1d4c8d160cdea02cab2c116b33"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -44,6 +56,12 @@ dependencies = [
  "time",
  "winapi",
 ]
+
+[[package]]
+name = "funty"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "itoa"
@@ -97,16 +115,18 @@ checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "memchr"
-version = "2.4.1"
+version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "nom"
-version = "5.1.2"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
+checksum = "9c5c51b9083a3c620fa67a2a635d1ce7d95b897e957d6b28ff9a5da960a103a6"
 dependencies = [
+ "bitvec",
+ "funty",
  "lexical-core",
  "memchr",
  "version_check",
@@ -150,6 +170,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "radium"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -188,6 +214,12 @@ dependencies = [
  "quote",
  "unicode-xid",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "thiserror"
@@ -259,6 +291,12 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "wyz"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "yaml-rust"

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -13,7 +13,7 @@ description = "A data-structure parameterization system for embedding context in
 anyhow = "1.0.32"
 serde_json = "1.0.57"
 thiserror = "1.0"
-nom = "5.1.2"
+nom = "6"
 lazy_static = "1.4.0"
 chrono = "0.4.19"
 

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -13,7 +13,7 @@ description = "A data-structure parameterization system for embedding context in
 anyhow = "1.0.32"
 serde_json = "1.0.57"
 thiserror = "1.0"
-nom = "6"
+nom = "7"
 lazy_static = "1.4.0"
 chrono = "0.4.19"
 

--- a/rs/src/fromnow.rs
+++ b/rs/src/fromnow.rs
@@ -1,3 +1,4 @@
+use crate::whitespace::ws;
 use anyhow::{anyhow, Result};
 use chrono::{DateTime, Duration, Utc};
 use nom::{
@@ -5,8 +6,7 @@ use nom::{
     bytes::complete::tag,
     character::complete::{digit1, multispace0},
     combinator::{map_res, opt},
-    error::ParseError,
-    sequence::{pair, tuple},
+    sequence::tuple,
     IResult,
 };
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -49,15 +49,6 @@ fn int(input: &str) -> IResult<&str, i64> {
         Ok(input.0.parse().map_err(|_| ())?)
     }
     map_res(tuple((digit1, multispace0)), to_int)(input)
-}
-
-/// chomp trailing whitespace
-// from https://github.com/Geal/nom/blob/master/doc/nom_recipes.md#whitespace
-fn ws<'a, F: 'a, O, E: ParseError<&'a str>>(inner: F) -> impl Fn(&'a str) -> IResult<&'a str, O, E>
-where
-    F: Fn(&'a str) -> IResult<&'a str, O, E>,
-{
-    map_res(pair(inner, multispace0), |input| Ok(input.0) as Result<O>)
 }
 
 fn sign(input: &str) -> IResult<&str, bool> {

--- a/rs/src/interpreter/parser.rs
+++ b/rs/src/interpreter/parser.rs
@@ -6,26 +6,17 @@
 #![allow(dead_code)]
 
 use super::Node;
+use crate::whitespace::ws;
 use anyhow::{anyhow, Result};
 use nom::{
     branch::alt,
     bytes::complete::{tag, take_till},
-    character::complete::{alpha1, alphanumeric1, char, digit1, multispace0},
+    character::complete::{alpha1, alphanumeric1, char, digit1},
     combinator::{complete, map_res, not, opt, recognize},
-    error::ParseError,
-    multi::{fold_many0, many0, separated_list},
+    multi::{fold_many0, many0, separated_list0},
     sequence::{delimited, pair, tuple},
     Err, IResult,
 };
-
-/// chomp whitespace at either end of a combinator
-// from https://github.com/Geal/nom/blob/master/doc/nom_recipes.md#whitespace
-fn ws<'a, F: 'a, O, E: ParseError<&'a str>>(inner: F) -> impl Fn(&'a str) -> IResult<&'a str, O, E>
-where
-    F: Fn(&'a str) -> IResult<&'a str, O, E>,
-{
-    delimited(multispace0, inner, multispace0)
-}
 
 // atomic values
 
@@ -150,7 +141,7 @@ fn array_literal(input: &str) -> IResult<&str, Node<'_>> {
     map_res(
         ws(delimited(
             char('['),
-            separated_list(ws(tag(",")), expression),
+            separated_list0(ws(tag(",")), expression),
             char(']'),
         )),
         node,
@@ -167,7 +158,7 @@ fn object_literal(input: &str) -> IResult<&str, Node<'_>> {
     map_res(
         ws(delimited(
             char('{'),
-            separated_list(
+            separated_list0(
                 ws(tag(",")),
                 tuple((ws(alt((string_str, ident_str))), tag(":"), ws(expression))),
             ),
@@ -263,7 +254,7 @@ fn function_expr(input: &str) -> IResult<&str, Node<'_>> {
             ws(tuple((
                 index_expr,
                 tag("("),
-                separated_list(ws(tag(",")), expression),
+                separated_list0(ws(tag(",")), expression),
                 tag(")"),
             ))),
             node,
@@ -323,8 +314,8 @@ pub(crate) fn parse_all(input: &str) -> anyhow::Result<Node> {
         Ok(("", node)) => Ok(node),
         Ok((unused, _)) => Err(anyhow!("Unexpected trailing characters {}", unused)),
         Err(Err::Incomplete(_)) => unreachable!(),
-        Err(Err::Error(e)) => Err(anyhow!("Parse error at {:?}", e.0)),
-        Err(Err::Failure(e)) => Err(anyhow!("Parse error at {:?}", e.0)),
+        Err(Err::Error(e)) => Err(anyhow!("Parse error at {:?}", e.input)),
+        Err(Err::Failure(e)) => Err(anyhow!("Parse error at {:?}", e.input)),
     }
 }
 
@@ -333,8 +324,8 @@ pub(crate) fn parse_partial(input: &str) -> anyhow::Result<(Node, &str)> {
     match complete(expression)(input) {
         Ok((unused, node)) => Ok((node, unused)),
         Err(Err::Incomplete(_)) => unreachable!(),
-        Err(Err::Error(e)) => Err(anyhow!("Parse error at {:?}", e.0)),
-        Err(Err::Failure(e)) => Err(anyhow!("Parse error at {:?}", e.0)),
+        Err(Err::Error(e)) => Err(anyhow!("Parse error at {:?}", e.input)),
+        Err(Err::Failure(e)) => Err(anyhow!("Parse error at {:?}", e.input)),
     }
 }
 

--- a/rs/src/interpreter/parser.rs
+++ b/rs/src/interpreter/parser.rs
@@ -217,7 +217,6 @@ fn index_expr(input: &str) -> IResult<&str, Node<'_>> {
 
     let (i, init) = unary_expr(input)?;
 
-    let mut init = Some(init);
     fold_many0(
         ws(alt((
             map_res(tuple((tag("["), expression, tag("]"))), index_op),
@@ -233,9 +232,9 @@ fn index_expr(input: &str) -> IResult<&str, Node<'_>> {
             ),
             map_res(tuple((tag("."), ident_str)), dot_node),
         ))),
-        // This is a FnMut but is only called once, so `take` it from the Option to avoid cloning
-        // it. See https://github.com/rust-bakery/nom/issues/1656.
-        move || init.take().unwrap(),
+        // This clone is necessary because backtracking may result in this
+        // parser running more than once.
+        move || init.clone(),
         |acc: Node, index_op: IndexOp| {
             let acc = Box::new(acc);
             match index_op {
@@ -285,12 +284,11 @@ macro_rules! binop {
         fn $name(input: &str) -> IResult<&str, Node<'_>> {
             let (i, init) = $higher_prec(input)?;
 
-            let mut init = Some(init);
             fold_many0(
                 pair($ops, $higher_prec),
-                // This is a FnMut but is only called once, so `take` it from the Option to avoid
-                // cloning it. See https://github.com/rust-bakery/nom/issues/1656.
-                move || init.take().unwrap(),
+                // This clone is necessary because backtracking may result in this
+                // parser running more than once.
+                move || init.clone(),
                 |acc: Node, (op, val): (&str, Node)| Node::Op(Box::new(acc), op, Box::new(val)),
             )(i)
         }

--- a/rs/src/lib.rs
+++ b/rs/src/lib.rs
@@ -6,6 +6,7 @@ mod interpreter;
 mod op_props;
 mod render;
 mod value;
+mod whitespace;
 
 pub use fromnow::use_test_now;
 pub use render::render;

--- a/rs/src/whitespace.rs
+++ b/rs/src/whitespace.rs
@@ -1,0 +1,12 @@
+use nom::{character::complete::multispace0, error::ParseError, sequence::delimited, IResult};
+
+/// chomp trailing whitespace
+// from https://github.com/Geal/nom/blob/master/doc/nom_recipes.md#whitespace
+pub(crate) fn ws<'a, F, O, E: ParseError<&'a str>>(
+    inner: F,
+) -> impl FnMut(&'a str) -> IResult<&'a str, O, E>
+where
+    F: FnMut(&'a str) -> IResult<&'a str, O, E>,
+{
+    delimited(multispace0, inner, multispace0)
+}

--- a/rs/src/whitespace.rs
+++ b/rs/src/whitespace.rs
@@ -1,6 +1,6 @@
 use nom::{character::complete::multispace0, error::ParseError, sequence::delimited, IResult};
 
-/// chomp trailing whitespace
+/// chomp whitespace at either end of a combinator
 // from https://github.com/Geal/nom/blob/master/doc/nom_recipes.md#whitespace
 pub(crate) fn ws<'a, F, O, E: ParseError<&'a str>>(
     inner: F,


### PR DESCRIPTION
This avoids some future incompatibilities in nom 5.

Note that this contains a workaround for a bug in nom, https://github.com/rust-bakery/nom/issues/1656.