### PR TITLE
Fix Rust JSON conversions for floats of small magnitude

### DIFF
--- a/py/jsone/newsfragments/466.bugfix
+++ b/py/jsone/newsfragments/466.bugfix
@@ -1,0 +1,1 @@
+Fix Rust JSON conversions for floats of small magnitude

--- a/rs/src/value.rs
+++ b/rs/src/value.rs
@@ -155,7 +155,7 @@ fn f64_to_serde_number(value: f64) -> Number {
     if value.fract() == 0.0 {
         if value < 0.0 && value > -(u32::MAX as f64) {
             return (value as i64).into();
-        } else if value < u32::MAX as f64 {
+        } else if value >= 0.0 && value < u32::MAX as f64 {
             return (value as u64).into();
         }
     }
@@ -251,9 +251,15 @@ mod test {
 
     #[test]
     fn conversions() {
+        // These floats are chosen such that they exercise the assumption that
+        // integer values outside (-u32::MAX..u32::MAX) are best represented as
+        // floats.
+        let small_float = (-100_000_000_000_000 as i64) as f64;
+        let big_float = (100_000_000_000_000 as i64) as f64;
+
         let serde_value = json!({
             "the": "quick",
-            "brown": ["fox", 2, 3.5, -5],
+            "brown": ["fox", 2, 3.5, -5, small_float, big_float],
             "over": true,
             "the": false,
             "lazy": 0,
@@ -270,6 +276,8 @@ mod test {
                         Number(2.0),
                         Number(3.5),
                         Number(-5.0),
+                        Number(small_float),
+                        Number(big_float),
                     ]),
                 ),
                 ("over".to_string(), Bool(true)),

--- a/specification.yml
+++ b/specification.yml
@@ -2274,6 +2274,11 @@ context: {a: 3, b: 2}
 template: {$eval: 'a * b * 3'}
 result: 18
 ---
+title: 'multiplication (2)'
+context: {a: 180000000000.0}
+template: {$eval: '(a * -1000)'}
+result: -180000000000000.0
+---
 title: 'division (1)'
 context: {a: 3, b: 2}
 template: {$eval: 'a / b'}


### PR DESCRIPTION
Fix Rust JSON conversions for floats of small magnitude, which would result in operations producing unexpected values.

Fixes #466

# Checklist

Before submitting a pull request, please check the following:

* [x] All tests pass for you on your machine for all implementations (all implementations must behave identically)
* [x] New tests have been added for any new functionality or to prevent regressions of a bugfix
* [x] Added a short description of the change to `newsfragments/$issue.bugfix` (for fixes) or `.feature` (for new features) or `.doc` (for documentation-only changes)
