### PR TITLE
Include img/* in docs site

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -15,6 +15,8 @@ echo === rebuilding dist
 
 echo === building book
 mdbook build
+# copy some files that mdbook does not
+cp img/* $BUILD_DIR
 
 echo === uploading
 (


### PR DESCRIPTION
It turns out these have not been included since January 2022!

There does not appear to be an `additional-other-stuff` option to the HTML renderer to copy images, so just copy them manually.

This has been run locally and the logo is now appearing on the main docs site.