### PR TITLE
Variables added in a $let do not persist outside of that $let

### DIFF
--- a/js/src/index.js
+++ b/js/src/index.js
@@ -165,7 +165,7 @@ operators.$let = (template, context) => {
     }
   });
 
-  var child_context = Object.assign(context, variables);
+  var child_context = Object.assign({}, context, variables);
 
   if (template.in == undefined) {
     throw new TemplateError('$let operator requires an `in` clause');

--- a/js/test/misc_test.js
+++ b/js/test/misc_test.js
@@ -38,4 +38,16 @@ suite('misc', function() {
   test('templates can\'t evaluate to an uncalled custom builtin', function() {
     assume(() => jsone({$eval: 'custom'}, { custom: () => null })).throws();
   });
+
+  test('$let doesn\'t leak variables', function() {
+    let template = {
+      $let: {
+        foo: 'bar',
+        baz: 'qux',
+      },
+      $eval: 'foo',
+    };
+
+    assume(() => jsone(template, {})).throws();
+  });
 });

--- a/js/test/misc_test.js
+++ b/js/test/misc_test.js
@@ -39,15 +39,4 @@ suite('misc', function() {
     assume(() => jsone({$eval: 'custom'}, { custom: () => null })).throws();
   });
 
-  test('$let doesn\'t leak variables', function() {
-    let template = {
-      $let: {
-        foo: 'bar',
-        baz: 'qux',
-      },
-      $eval: 'foo',
-    };
-
-    assume(() => jsone(template, {})).throws();
-  });
 });

--- a/py/jsone/newsfragments/473.bugfix
+++ b/py/jsone/newsfragments/473.bugfix
@@ -1,0 +1,1 @@
+For JavaScript, Variables added in a $let do not persist outside of that $let any more.

--- a/specification.yml
+++ b/specification.yml
@@ -808,6 +808,16 @@ template:
       then: "${fromNow('1 hour')}"
       else: "f"
 result: '1 HOUR'
+---
+title: $let doesn't leak variables
+context: {}
+template:
+  - $let: 
+      foo: 'bar'
+      baz: 'qux'
+    in: {$eval: 'foo'}
+  - $eval: 'foo'
+error: 'InterpreterError at template[1]: unknown context value foo'
 ################################################################################
 ---
 section:  $map


### PR DESCRIPTION
Fixes #473

For JavaScript, Variables added in a `$let` do not persist outside of that `$let` any more

# Checklist

Before submitting a pull request, please check the following:

* [X] All tests pass for you on your machine for all implementations (all implementations must behave identically)
* [X] New tests have been added for any new functionality or to prevent regressions of a bugfix
* [X] Added a short description of the change to `newsfragments/$issue.bugfix` (for fixes) or `.feature` (for new features) or `.doc` (for documentation-only changes)
