### PR TITLE
do a better job pushing tags

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -78,7 +78,8 @@ upload_py() {
 }
 
 push_git() {
-    git push upstream main:main --follow-tags
+    git push upstream main:main
+    git push upstream --follow-gags "v$version"
 }
 
 # Check stuff

--- a/release.sh
+++ b/release.sh
@@ -79,7 +79,7 @@ upload_py() {
 
 push_git() {
     git push upstream main:main
-    git push upstream --follow-gags "v$version"
+    git push upstream --follow-tags "v$version"
 }
 
 # Check stuff


### PR DESCRIPTION
The `--follow-tags` option on its own didn't work to upload the v4.6.0 tag, but I ran this next command manually and it did send the tag.