### PR TITLE
fix json encoding of extended unicode

### DIFF
--- a/specification.yml
+++ b/specification.yml
@@ -704,17 +704,17 @@ result:   '[2,5,10]'
 title:    representation of various unicode codepoints are consistent
 context:  {}
 template: {$json: ["\x10", "Z", "\u0103","\U0001F809"]}
-result:   "[\"\\u0010\",\"Z\",\"\u0103\",\"\U0001F809\"]"
+result:   "[\"\\u0010\",\"Z\",\"\u0103\",\"\\uD83E\\uDC09\"]"
 ---
 title:    sorting pairs by unicode key strings sorts lexically by codepoint
 context:  {}
 template: {$json: {"\u3347\u0050": 1, "\uE1FF\u0100": 2, "\u0055\u0045": 3}}
-result:   "{\"\u0055\u0045\":3,\"\u3347\u0050\":1,\"\uE1FF\u0100\":2}"
+result:   "{\"\u0055\u0045\":3,\"\u3347\u0050\":1,\"\\uE1FF\u0100\":2}"
 ---
 title:    sorting pairs by unicode key strings sorts lexically by codepoint, even with chars above base plane
 context:  {}
 template: {$json: {"\U0001F809\u732b":'hey', "Z\U00010000P": 1, "\U000E1FFF\u0103": 2, "UaE": 3}}
-result:   "{\"UaE\":3,\"Z\U00010000P\":1,\"\U0001F809\u732b\":\"hey\",\"\U000E1FFF\u0103\":2}"
+result:   "{\"UaE\":3,\"Z\\uD800\\uDC00P\":1,\"\\uD83E\\uDC09\u732b\":\"hey\",\"\\uDB47\\uDFFF\u0103\":2}"
 ---
 title:    $json with undefined properties
 context:  {}


### PR DESCRIPTION
I'm not set up to run the existing implementations.  These tests were found while implementing in .Net, which has a notoriously strict JSON parser.

Resolves #500 by fixing JSON-escaping of unicode chars in three tests.

# Checklist

Before submitting a pull request, please check the following:

* [ ] All tests pass for you on your machine for all implementations (all implementations must behave identically)
* [x] New tests have been added for any new functionality or to prevent regressions of a bugfix
* [ ] Added a short description of the change to `newsfragments/$issue.bugfix` (for fixes) or `.feature` (for new features) or `.doc` (for documentation-only changes)

