### PR TITLE
Better unicode-non-escaping tests

### DIFF
--- a/docs/src/operators.md
+++ b/docs/src/operators.md
@@ -48,6 +48,11 @@ not evaluate the value (use `$eval` for that). While this can be useful in some
 cases, it is an unusual case to include a JSON string in a larger data
 structure.
 
+Parsing the result of this operator with any compliant JSON parser will give
+the same results. However, the encoding may differ between implementations of
+JSON-e. For example, numeric representations or string escapes may differ
+between implementations.
+
 ```yaml,json-e
 template: {$json: [a, b, {$eval: 'a+b'}, 4]}
 context:  {a: 1, b: 2}

--- a/specification.yml
+++ b/specification.yml
@@ -701,13 +701,29 @@ context:  {a: 1, b: 2}
 template: {$json: [2, 5, {$eval: 'a + b + 7'}]}
 result:   '[2,5,10]'
 ---
-title:    representation of various unicode codepoints are consistent
+title:    ASCII non-printable character is u-escaped
 context:  {}
-template: {$json: ["\x10", "Z", "\u0103","\U0001F809"]}
-result:   "[\"\\u0010\",\"Z\",\"\u0103\",\"\U0001F809\"]"
+template: {$json: ["\x10"]}
+result:   "[\"\\u0010\"]"
+---
+title:    ASCII printable character is not escaped
+context:  {}
+template: {$json: ["Z"]}
+result:   "[\"Z\"]"
+---
+title:    Unicode BMP character is not escaped
+context:  {}
+template: {$json: ["ă"]}
+result:   "[\"ă\"]"
+---
+title:    Unicode supplementary plane character U+1F150 is not escaped
+context:  {}
+template: {$json: ["🅐"]}
+result:   "[\"🅐\"]"
 ---
 title:    sorting pairs by unicode key strings sorts lexically by codepoint
 context:  {}
+# Note that these `\u` escapes are interpreted into characters by YAML, not by JSON-e
 template: {$json: {"\u3347\u0050": 1, "\uE1FF\u0100": 2, "\u0055\u0045": 3}}
 result:   "{\"\u0055\u0045\":3,\"\u3347\u0050\":1,\"\uE1FF\u0100\":2}"
 ---

--- a/specification.yml
+++ b/specification.yml
@@ -716,11 +716,6 @@ context:  {}
 template: {$json: ["ă"]}
 result:   "[\"ă\"]"
 ---
-title:    Unicode supplementary plane character U+1F150 is not escaped
-context:  {}
-template: {$json: ["🅐"]}
-result:   "[\"🅐\"]"
----
 title:    sorting pairs by unicode key strings sorts lexically by codepoint
 context:  {}
 # Note that these `\u` escapes are interpreted into characters by YAML, not by JSON-e


### PR DESCRIPTION
The previous form of this test was not clear that the intention was to _not_ escape unicode characters.  See #500 and #501 for discussion.

Fixes #500.