### PR TITLE
add tests for zero-argument functions

### DIFF
--- a/internal/misc_test.go
+++ b/internal/misc_test.go
@@ -1,0 +1,18 @@
+package jsone
+
+import (
+	"testing"
+
+	"github.com/json-e/json-e/v4/internal/interpreter"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNoArgFunction(t *testing.T) {
+	// Set a fixed 'now', if one isn't specified
+	context := make(map[string]interface{})
+	context["noargs"] = interpreter.WrapFunction(func() float64 { return 42.0 })
+
+	result, err := Render(map[string]interface{}{"$eval": "noargs()"}, context)
+	require.NoError(t, err)
+	require.Equal(t, result, 42.0)
+}

--- a/js/test/misc_test.js
+++ b/js/test/misc_test.js
@@ -46,4 +46,9 @@ suite('misc', function() {
     assume(() => jsone({}, "two")).throws();
     assume(() => jsone({}, [{}])).throws();
   });
+
+  test('Argument-less functions are OK', function() {
+    let my_builtin = () => 42;
+    assume(jsone({$eval: 'my_builtin()'}, {my_builtin})).eql(42);
+  });
 });

--- a/py/test/test_misc.py
+++ b/py/test/test_misc.py
@@ -14,6 +14,13 @@ def test_custom_builtin():
     assert render({"$eval": "my_builtin(3, 4)"}, {"my_builtin": my_builtin}) == 5
 
 
+def test_no_arg_func():
+    def my_builtin():
+        return 42
+
+    assert render({"$eval": "my_builtin()"}, {"my_builtin": my_builtin}) == 42
+
+
 def test_non_object_context():
     with pytest.raises(JSONTemplateError):
         render({}, None)

--- a/rs/src/interpreter/parser.rs
+++ b/rs/src/interpreter/parser.rs
@@ -615,6 +615,14 @@ mod test {
     }
 
     #[test]
+    fn test_parse_no_args_fn() {
+        assert_eq!(
+            parse_all("f()").unwrap(),
+            Node::Func(Box::new(Node::Ident("f")), vec![],)
+        );
+    }
+
+    #[test]
     fn test_parse_all_err() {
         assert!(parse_all("~~~").is_err());
     }


### PR DESCRIPTION
Adds some tests as suggested in #507.

Fixes #507.