### PR TITLE
Valid identifier syntax

### DIFF
--- a/docs/src/expressions.md
+++ b/docs/src/expressions.md
@@ -47,6 +47,11 @@ context: {x: 'quick', z: 'sort'}
 result: ['quick', 'sort', 'quicksort']
 ```
 
+Valid identifiers for context references follow the requirements of many
+programming languages: identifiers may only contain letters, underscores, and
+numbers, but may not start with a number. This does imply that the context
+object may only have keys that meet these requirements.
+
 ## Arithmetic Operations
 
 The usual arithmetic operators are all defined, with typical associativity and
@@ -128,8 +133,8 @@ does not have `prop`, while `obj['prop']` will evaluate to `null`.
 
 ```yaml,json-e
 template: {$eval: 'v.a + v["b"]'}
-context: {v: {a: 'apple', b: 'bananna', c: 'carrot'}}
-result: 'applebananna'
+context: {v: {a: 'apple', b: 'banana', c: 'carrot'}}
+result: 'applebanana'
 ```
 
 Note that the object can be a literal expression:
@@ -139,6 +144,13 @@ template: {$eval: '{ENOMEM:"Out of memory", ENOCPU:"Out of CPUs"}[msgid]'}
 context: {msgid: ENOMEM}
 result: 'Out of memory'
 ```
+
+When using the dot-syntax, e.g. `.prop`, identifiers may only contain letters,
+underscores, and numbers, but may not start with a number (just like for context
+references). While the context object may only have keys that meet these
+requirements, nested objects may have keys in any format. Keys that are not in
+the identifier format must be accessed using the bracket-name syntax, e.g.
+`['my-prop']`.
 
 ## Indexing and Slicing
 

--- a/internal/interpreter/util.go
+++ b/internal/interpreter/util.go
@@ -273,7 +273,7 @@ var contextVariablePattern = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
 func IsValidContext(context map[string]interface{}) error {
 	for k, v := range context {
 		if !contextVariablePattern.MatchString(k) {
-			return fmt.Errorf("context variable '%s' doesn't match pattern: %s", k, contextVariablePattern.String())
+			return fmt.Errorf("top level keys of context must follow %s", contextVariablePattern.String())
 		}
 		if err := IsValidData(v); err != nil {
 			return err

--- a/internal/jsone.go
+++ b/internal/jsone.go
@@ -19,7 +19,7 @@ import (
 func Render(template interface{}, context map[string]interface{}) (interface{}, error) {
 	// Validate input
 	if err := i.IsValidContext(context); err != nil {
-		panic(err)
+		return nil, err
 	}
 
 	// Inherit functions from builtins

--- a/internal/jsone_test.go
+++ b/internal/jsone_test.go
@@ -19,18 +19,10 @@ type testCase struct {
 	Template interface{}            `json:"template"`
 	Result   interface{}            `json:"result"`
 	Error    interface{}            `json:"error"` // bool, string or nil
-	Panic    interface{}            `json:"panic"` // bool, true if panic is expected
 }
 
 func (c *testCase) Test(t *testing.T) {
 	require.Empty(t, c.Section, "sections aren't test cases")
-
-	if c.Panic != nil {
-		require.Panics(t, func() {
-			Render(c.Template, c.Context) // nolint:errcheck
-		})
-		return
-	}
 
 	// Set a fixed 'now', if one isn't specified
 	context := make(map[string]interface{})

--- a/specification.yml
+++ b/specification.yml
@@ -4031,6 +4031,11 @@ context: {key: 'null'}
 template: {$eval: 'key'}
 result: 'null'
 ---
+title: 'property that is also a function name'
+context: {min: abc}
+template: {$eval: 'min'}
+result: abc
+---
 title: 'missing property'
 context: {key: {a: 1}}
 template: {$eval: 'key.b'}
@@ -4076,6 +4081,81 @@ context: {key: abc, values: {abc: 2, def: 3}}
 template: {$eval: 'values[key]'}
 result: 2
 ---
+title: 'property starting with underscore'
+context: {_key: abc}
+template: {$eval: '_key'}
+result: abc
+---
+title: 'property containing underscore'
+context: {my_key: abc}
+template: {$eval: 'my_key'}
+result: abc
+---
+title: 'property containing hyphen'
+context: {my-key: abc}
+template: {$eval: 'my-key'}
+error: 'TemplateError: top level keys of context must follow /[a-zA-Z_][a-zA-Z0-9_]*/'
+---
+title: 'property starting with capital'
+context: {Key: abc}
+template: {$eval: 'Key'}
+result: abc
+---
+title: 'property containing capital'
+context: {kEy: abc}
+template: {$eval: 'kEy'}
+result: abc
+---
+title: 'case sensitivity of keys'
+context: {key: abc}
+template: {$eval: 'Key'}
+error: 'InterpreterError: unknown context value Key'
+---
+title: 'property starting with number'
+context: {'2fast': abc}
+template: {$eval: '2fast'}
+error: 'TemplateError: top level keys of context must follow /[a-zA-Z_][a-zA-Z0-9_]*/'
+---
+title: 'property containing number'
+context: {furious5: abc}
+template: {$eval: 'furious5'}
+result: abc
+---
+title: 'nested property starting with underscore'
+context: {key: {_foo: abc}}
+template: {$eval: 'key._foo'}
+result: abc
+---
+title: 'nested property containing underscore'
+context: {key: {foo_bar: abc}}
+template: {$eval: 'key.foo_bar'}
+result: abc
+---
+title: 'nested property containing hyphen'
+context: {key: {my-foo: abc}}
+template: {$eval: 'key.my-foo'}
+error: 'InterpreterError: object has no property "my"'
+---
+title: 'nested property containing hyphen using brackets'
+context: {key: {my-foo: abc}}
+template: {$eval: "key['my-foo']"}
+result: abc
+---
+title: 'nested property starting with capital'
+context: {key: {Foo: abc}}
+template: {$eval: 'key.Foo'}
+result: abc
+---
+title: 'nested property containing capital'
+context: {key: {fOo: abc}}
+template: {$eval: 'key.fOo'}
+result: abc
+---
+title: 'case sensitivity of nested keys'
+context: {key: {foo: abc}}
+template: {$eval: 'key.Foo'}
+error: 'InterpreterError: object has no property "Foo"'
+---
 title: 'property access with number'
 context:
   obj: {'13': 15}
@@ -4104,6 +4184,11 @@ template: {$eval: 'key.valueOf'}
 error: 'InterpreterError: infix: . expects objects'
 ---
 title: 'non-identifier after dot'
+context: {key: {}}
+template: {$eval: 'key.{'}
+error: 'SyntaxError: Found: { token, expected one of: identifier'
+---
+title: 'non-identifier after dot (2)'
 context: {key: {}}
 template: {$eval: 'key.{'}
 error: 'SyntaxError: Found: { token, expected one of: identifier'

--- a/specification.yml
+++ b/specification.yml
@@ -126,7 +126,6 @@ title: invalid context
 context: {'a b c': 1}
 template: {}
 error: 'TemplateError: top level keys of context must follow /[a-zA-Z_][a-zA-Z0-9_]*/'
-panic: true
 ################################################################################
 ---
 section:  $if operator


### PR DESCRIPTION
Resolves #480 

Adds docs and tests for property identifiers, both in the context object and in accessors.

I expect all implementations should pass these.  I verified most of them in the playground.

# Checklist

Before submitting a pull request, please check the following:

* [ ] All tests pass for you on your machine for all implementations (all implementations must behave identically)
* [x] New tests have been added for any new functionality or to prevent regressions of a bugfix
* [ ] Added a short description of the change to `newsfragments/$issue.bugfix` (for fixes) or `.feature` (for new features) or `.doc` (for documentation-only changes)
