### PR TITLE
Improve support for Unicode strings

### DIFF
--- a/docs/src/expressions.md
+++ b/docs/src/expressions.md
@@ -167,6 +167,8 @@ treated as "half-open", meaning that the result contains the first index and
 does not contain the second index.  A "backward" slice with the start index
 greater than the end index is treated as empty.
 
+Strings are treated as a sequence of Unicode codepoints.
+
 ```yaml,json-e
 template:
   - {$eval: '[array[1], string[1]]'}
@@ -177,11 +179,11 @@ template:
   - {$eval: '[array[-2], string[-2]]'}
   - {$eval: '[array[-2:], string[-2:]]'}
   - {$eval: '[array[:-3], string[:-3]]'}
-context: {array: ['a', 'b', 'c', 'd', 'e'], string: 'abcde'}
+context: {array: ['a', 'b', '☪', 'd', 'e'], string: 'ab☪de'}
 result:
   - ['b', 'b']
-  - [['b', 'c', 'd'], 'bcd']
-  - [['c', 'd', 'e'], 'cde']
+  - [['b', '☪', 'd'], 'b☪d']
+  - [['☪', 'd', 'e'], '☪de']
   - [['a', 'b'], 'ab']
   - [[], '']
   - ['d', 'd']

--- a/py/jsone/newsfragments/390.bugfix
+++ b/py/jsone/newsfragments/390.bugfix
@@ -1,0 +1,1 @@
+Support for Unicode strings has been improved and made consistent across implementations: all indexing and slicing is in terms of codepoints, rather than bytes.

--- a/specification.yml
+++ b/specification.yml
@@ -4106,6 +4106,11 @@ context: {}
 template: {$eval: '"12345"[-2]'}
 result: '4'
 ---
+title: 'string indexing (unicode)'
+context: {key: "\u2622abc\U0001F601"}
+template: {$eval: '[key[0], key[2], key[-1]]'}
+result: ["\u2622", "b", "\U0001F601"]
+---
 title: 'string indexing (noninteger)'
 context: {}
 template: {$eval: '"12345"[2.5]'}
@@ -4460,7 +4465,7 @@ template: {$eval: 'key.sort'}
 error: 'InterpreterError: infix: . expects objects'
 ################################################################################
 ---
-section: expression language - array slicing
+section: expression language - slicing
 ---
 title: 'array slicing (full slice)'
 context: {key: [1,2,3,4,5]}
@@ -4472,9 +4477,19 @@ context: {key: [1,2,3,4,5]}
 template: {$eval: 'key[0:3]'}
 result: [1,2,3]
 ---
+title: 'array slicing (out of order)'
+context: {key: [1,2,3,4,5]}
+template: {$eval: 'key[3:2]'}
+result: []
+---
 title: 'array slicing (negative indices)'
 context: {key: [1,2,3,4,5]}
 template: {$eval: 'key[-5:-1]'}
+result: [1,2,3,4]
+---
+title: 'array slicing (negative indices larger than length)'
+context: {key: [1,2,3,4,5]}
+template: {$eval: 'key[-10:-1]'}
 result: [1,2,3,4]
 ---
 title: 'array slicing (noninteger first index)'
@@ -4551,6 +4566,41 @@ title: 'slicing object'
 context: {key: {x: 10}}
 template: {$eval: 'key[2:]'}
 error: true
+---
+title: 'string slicing - full'
+context: {key: "hello"}
+template: {$eval: 'key[0:6]'}
+result: "hello"
+---
+title: 'string slicing - prefix'
+context: {key: "hello"}
+template: {$eval: 'key[0:3]'}
+result: "hel"
+---
+title: 'string slicing - omitted first index'
+context: {key: "hello"}
+template: {$eval: 'key[:3]'}
+result: "hel"
+---
+title: 'string slicing - omitted second index'
+context: {key: "hello"}
+template: {$eval: 'key[3:]'}
+result: "lo"
+---
+title: 'string slicing - negative index'
+context: {key: "hello"}
+template: {$eval: 'key[-3:]'}
+result: "llo"
+---
+title: 'string slicing - negative greater than length'
+context: {key: "hello"}
+template: {$eval: 'key[-9:]'}
+result: "hello"
+---
+title: 'string slicing - unicode indices'
+context: {key: "\u2622abc\U0001F601"}
+template: {$eval: '[key[0:1], key[1:4], key[-1:]]'}
+result: ["\u2622", "abc", "\U0001F601"]
 ################################################################################
 ---
 section: expression language - function calls

--- a/specification.yml
+++ b/specification.yml
@@ -4587,10 +4587,15 @@ context: {key: "hello"}
 template: {$eval: 'key[3:]'}
 result: "lo"
 ---
-title: 'string slicing - negative index'
+title: 'string slicing - negative index, omitted second index'
 context: {key: "hello"}
 template: {$eval: 'key[-3:]'}
 result: "llo"
+---
+title: 'string slicing - negative index'
+context: {key: "hello"}
+template: {$eval: 'key[-3:4]'}
+result: "ll"
 ---
 title: 'string slicing - negative greater than length'
 context: {key: "hello"}


### PR DESCRIPTION
In particular, all strings are indexed and sliced by codepoint, rather than by byte. This is fairly inefficient, because it involves scanning the strings, so the JS and Go implementations take a shortcut for ASCII-only strings, which are probably the common case.
