### PR TITLE
Enforce that `split` always has two arguments.

### DIFF
--- a/internal/jsone.go
+++ b/internal/jsone.go
@@ -170,32 +170,17 @@ var builtin = map[string]interface{}{
 	"rstrip": i.WrapFunction(func(s string) string {
 		return strings.TrimRightFunc(s, unicode.IsSpace)
 	}),
-	"split": i.WrapFunction(func(v interface{}, d ...interface{}) (interface{}, error) {
+	"split": i.WrapFunction(func(v interface{}, d interface{}) (interface{}, error) {
+		_, isNumber := d.(float64)
+		_, isString := d.(string)
 
-		// We use variadic because golang doesn't support optional parameters
-		if len(d) > 1 {
-			return "", fmt.Errorf("split(value, delimiter) takes at-most two arguments, but was given %d", len(d))
-		}
-
-		var reference interface{} = nil
-
-		if len(d) == 1 {
-			reference = d[0]
-			_, isNumber := reference.(float64)
-			_, isString := reference.(string)
-
-			if !isString && !isNumber {
-				return "", fmt.Errorf("split(value, delimeter) delimeter must be a string or a number")
-			}
+		if !isString && !isNumber {
+			return "", fmt.Errorf("split(value, delimeter) delimeter must be a string or a number")
 		}
 
 		switch val := v.(type) {
 		case string:
-			var delimeter string = ""
-
-			if reference != nil {
-				delimeter = fmt.Sprintf("%v", reference)
-			}
+			delimeter := fmt.Sprintf("%v", d)
 			split := strings.Split(val, delimeter)
 			result := make([]interface{}, len(split))
 			for i, v := range split {

--- a/js/src/builtins.js
+++ b/js/src/builtins.js
@@ -125,8 +125,8 @@ module.exports = (context) => {
   });
 
   define('split', builtins, {
-    minArgs: 1,
-    variadic: 'string|number',
+    minArgs: 2,
+    argumentTests: ['string', 'string|number'],
     invoke: (input, delimiter) => input.split(delimiter)
   });
 

--- a/py/jsone/builtins.py
+++ b/py/jsone/builtins.py
@@ -132,7 +132,7 @@ def build():
 
         return str(separator).join(string_list)
 
-    @builtin("split", variadic=is_string_or_number, minArgs=1)
+    @builtin("split", argument_tests=[is_string, is_string_or_number], minArgs=2)
     def split(s, d=""):
         if not d and is_string(s):
             return list(s)

--- a/specification.yml
+++ b/specification.yml
@@ -2096,6 +2096,11 @@ context: {}
 template: {$eval: "split([])"}
 error: 'BuiltinError: invalid arguments to builtin: split'
 ---
+title: split with only one argument
+context: {}
+template: {$eval: "split('abc')"}
+error: 'BuiltinError: invalid arguments to builtin: split'
+---
 title: join with string separator
 context: {}
 template: {$eval: "join(['join', 'me'], ' ')"}


### PR DESCRIPTION
The one-argument form existed for JS, Python, and Go -- but not Rust. But it produced different results for JS (single-element list) and Python/Go (list of single characters).

Fixes #521.