### PR TITLE
New feature: `$find`

### DIFF
--- a/docs/src/operators.md
+++ b/docs/src/operators.md
@@ -256,10 +256,24 @@ Using context variables:
 
 ```yaml,json-e
 template:
-  $map: [2, 4, 6]
+  $find: [2, 4, 6]
   each(x): a == x
 context: {a: 4}
 result: 4
+```
+
+Omitting from parent:
+
+```yaml,json-e
+template:
+  a: 1
+  b:
+    $find: [2, 4, 6]
+    each(x): b == x
+context:
+  b: 3
+result:
+  a: 1
 ```
 
 The `each` function can define two variables, in which case the second is the 0-based index of the element.

--- a/docs/src/operators.md
+++ b/docs/src/operators.md
@@ -236,6 +236,42 @@ context:  {}
 result: {ax: 2, bx: 3, cx: 4}
 ```
 
+## `$find`
+
+The `$find` operator evaluates an expression for each value of the given array or object,
+returning the first value for which the expression evaluates to `true`.
+
+If there are no matches the result is either `null` or if used within an object or array, omitted
+from the parent object.
+
+```yaml,json-e  
+template:
+  $find: [2, 4, 6]
+  each(x): x == 4
+context: {}
+result: 4
+```
+
+Using context variables:
+
+```yaml,json-e
+template:
+  $map: [2, 4, 6]
+  each(x): a == x
+context: {a: 4}
+result: 4
+```
+
+The `each` function can define two variables, in which case the second is the 0-based index of the element.
+
+```yaml,json-e
+template:
+  $find: [2, 4, 6]
+  each(x,i): i == 2
+context: {}
+result: 6
+```
+
 ## `$match`
 
 The `$match` operator is not dissimilar to pattern matching operators.  It gets

--- a/docs/src/operators.md
+++ b/docs/src/operators.md
@@ -238,7 +238,7 @@ result: {ax: 2, bx: 3, cx: 4}
 
 ## `$find`
 
-The `$find` operator evaluates an expression for each value of the given array or object,
+The `$find` operator evaluates an expression for each value of the given array.
 returning the first value for which the expression evaluates to `true`.
 
 If there are no matches the result is either `null` or if used within an object or array, omitted

--- a/internal/jsone.go
+++ b/internal/jsone.go
@@ -698,7 +698,7 @@ var operators = map[string]operator{
 			s, ok := eachTemplate.(string)
 			if !ok {
 				return nil, TemplateError{
-					Message:  "$if expects a string expression",
+					Message:  "$find expects a string expression",
 					Template: template,
 				}
 			}

--- a/internal/jsone.go
+++ b/internal/jsone.go
@@ -639,6 +639,92 @@ var operators = map[string]operator{
 			}
 		}
 	},
+	"$find": func(template, context map[string]interface{}) (interface{}, error) {
+		value, err := render(template["$find"], context)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(template) != 2 {
+			return nil, TemplateError{
+				Message:  "$find must have exactly two properties",
+				Template: template,
+			}
+		}
+
+		// Find the each(...) key
+		var eachKey string
+		for k := range template {
+			if k == "$find" {
+				continue
+			}
+			eachKey = k
+		}
+
+		// Validate against each(...) key pattern
+		m := eachKeyPattern.FindStringSubmatch(eachKey)
+		if m == nil {
+			return nil, TemplateError{
+				Message:  "$find requires a property on the form 'each(identifier)'",
+				Template: template,
+			}
+		}
+		eachIdentifier := m[1]
+		eachIndex := m[3]
+		additionalContextVars := 1
+		if len(eachIndex) > 0 {
+			additionalContextVars = 2
+		}
+		eachTemplate := template[eachKey]
+
+		val, ok := value.([]interface{})
+		if !ok {
+			return nil, TemplateError{
+				Message:  "$find expected an array",
+				Template: template,
+			}
+		}
+		
+		for idx, entry := range val {
+			c := make(map[string]interface{}, len(context)+additionalContextVars)
+			for k, v := range context {
+				c[k] = v
+			}
+			c[eachIdentifier] = entry
+			if len(eachIndex) > 0 {
+				c[eachIndex] = float64(idx)
+			}
+			
+			s, ok := eachTemplate.(string)
+			if !ok {
+				return nil, TemplateError{
+					Message:  "$if expects a string expression",
+					Template: template,
+				}
+			}
+
+			val, err := i.Parse(s, c)
+			if err != nil {
+				return nil, TemplateError{
+					Message:  err.Error(),
+					Template: template,
+				}
+			}
+
+			if i.IsTruthy(val) {
+				r, err := render(entry, c)
+				if err != nil {
+					return nil, TemplateError{
+						Message:  err.Error(),
+						Template: template,
+					}
+				}
+				return r, nil;
+			}
+		}
+		
+		return deleteMarker, nil
+	},
 	"$match": func(template, context map[string]interface{}) (interface{}, error) {
 		if err := restrictProperties(template, "$match"); err != nil {
 			return nil, err

--- a/internal/jsone.go
+++ b/internal/jsone.go
@@ -680,7 +680,7 @@ var operators = map[string]operator{
 		val, ok := value.([]interface{})
 		if !ok {
 			return nil, TemplateError{
-				Message:  "$find expected an array",
+				Message:  "$find expects an array",
 				Template: template,
 			}
 		}

--- a/py/jsone/newsfragments/525.feature
+++ b/py/jsone/newsfragments/525.feature
@@ -1,0 +1,3 @@
+The `$find` operator evaluates an expression for each value of the given array or object, returning
+the first value for which the expression evaluates to `true`. If there are no matches the result is
+either `null` or if used within an object or array, omitted from the parent object.

--- a/py/jsone/render.py
+++ b/py/jsone/render.py
@@ -327,8 +327,10 @@ def find(template, context):
 
     subcontext = context.copy()
     for i, elt in enumerate(value):
-        subcontext[each_var] = elt
         if each_idx is None:
+            subcontext[each_var] = elt
+        else:
+            subcontext[each_var] = elt
             subcontext[each_idx] = i
 
         if parse(each_template, subcontext):

--- a/py/jsone/render.py
+++ b/py/jsone/render.py
@@ -327,10 +327,8 @@ def find(template, context):
 
     subcontext = context.copy()
     for i, elt in enumerate(value):
+        subcontext[each_var] = elt
         if each_idx is None:
-            subcontext[each_var] = elt
-        else:
-            subcontext[each_var] = elt
             subcontext[each_idx] = i
 
         if parse(each_template, subcontext):

--- a/specification.yml
+++ b/specification.yml
@@ -1102,6 +1102,113 @@ template: {$map: {a: 1, b: 2, c: 3}, 'each(y)': {'${y.key}x': {$eval: 'y.val + 1
 result:   {ax: 2, bx: 3, cx: 4}
 ################################################################################
 ---
+section: $find operator
+---
+title:   $find, simple find
+context: {}
+template: {$find: [2, 4, 6], each(x): 'x == 2' }
+result: 2
+---
+title:   $find, simple find with context
+context: {a: 2}
+template: {$find: [2, 4, 6], each(x): 'x == a' }
+result: 2
+---
+title:   $find respects delete marker
+context: {}
+template: {a: 1, b: {$find: [1,2,3], 'each(x)': 'x > 4' }}
+result: {a: 1}
+---
+title:   $find, complicated find with $let
+context: {}
+template:
+  $let:
+    needle:
+      $find: [1, 2, 3]
+      each(entry): entry == 2
+  in:
+    $eval: needle
+result: 2
+---
+title:    $find complex identifier
+context:  {a: 1}
+template:
+  $find: [2, 4, 6]
+  each(my_identifier97): 'my_identifier97 == 1 || my_identifier97 == 4'
+result: 4
+---
+title:    $find array index variable
+context: {}
+template:
+  $find: [1, 2, 3]
+  each(y,i): 'i == 2'
+result: 3
+---
+title:    $find no args
+context:  {}
+template:
+  $find: [1, 2, 3]
+  each(): 'y.k'
+error: 'TemplateError: $find has undefined properties: each()'
+---
+title:    $find too many args
+context:  {}
+template:
+  $find: [1, 2, 3]
+  each(k,v,i): 'y.k'
+error: 'TemplateError: $find has undefined properties: each(k,v,i)'
+---
+title:    $find requires an array, not string
+context:  {}
+template:
+  $find: "a, b, c"
+  each(y): 'y.k'
+error: 'TemplateError: $find value must evaluate to an array'
+---
+title:    $find requires an array, not number
+context:  {}
+template:
+  $find: 10.1
+  each(y): 'y.k'
+error: 'TemplateError: $find value must evaluate to an array'
+---
+title:    $find requires an array, not null
+context:  {}
+template:
+  $find: null
+  each(y): 'y.k'
+error: 'TemplateError: $find value must evaluate to an array'
+---
+title:    $find requires an array, not object
+context:  {}
+template:
+  $find: {a: 1}
+  each(y): 'y.k'
+error: 'TemplateError: $find value must evaluate to an array'
+---
+title:    $find with undefined properties
+context:  {a: 1}
+template:
+  $find: [2, 4, 6]
+  each(x): 'x + a'
+  foo: 'bar'
+error: 'TemplateError: $find has undefined properties: foo'
+---
+title:    $find each must be string, not number
+context:  {}
+template:
+  $find: [1,2,3]
+  each(a): 1
+error: 'TemplateError: each can evaluate string expressions only'
+---
+title:    $find each must be string, not object
+context:  {}
+template:
+  $find: [1,2,3]
+  each(a): {a: 1}
+error: 'TemplateError: each can evaluate string expressions only'
+################################################################################
+---
 section: $match operator
 ---
 title:    $match, 2 matches, ordered by lexcial sorting of property names


### PR DESCRIPTION
This change introduces a new `$find` operator which evaluates an expression for each value of the given array or object, returning the first value for which the expression evaluates to `true`.

If there are no matches the result is either null or if used within an object or array, omitted
from the parent object.

Discussed in #525

# Checklist

Before submitting a pull request, please check the following:

* [X] All tests pass for you on your machine for all implementations (all implementations must behave identically)
* [X] New tests have been added for any new functionality or to prevent regressions of a bugfix
* [X] Added a short description of the change to `newsfragments/$issue.bugfix` (for fixes) or `.feature` (for new features) or `.doc` (for documentation-only changes)
