### PR TITLE
Removed print statement in evaluators::slice from rust implementation. 

### DIFF
--- a/py/jsone/newsfragments/slice_print.bugfix
+++ b/py/jsone/newsfragments/slice_print.bugfix
@@ -1,0 +1,1 @@
+Removed unnecessary print statement from rust implementation. 

--- a/rs/src/interpreter/evaluator.rs
+++ b/rs/src/interpreter/evaluator.rs
@@ -259,7 +259,6 @@ fn slice(context: &Context, v: &Node, a: Option<&Node>, b: Option<&Node>) -> Res
 
         _ => unreachable!(),
     });
-    println!("r: {:?}", r);
     r
 }
 


### PR DESCRIPTION
Removed a print statement that looks like a implementation/debugging artifact.

# Checklist

Before submitting a pull request, please check the following:

* [x] All tests pass for you on your machine for all implementations (all implementations must behave identically)
* [ ] New tests have been added for any new functionality or to prevent regressions of a bugfix
* [x] Added a short description of the change to `newsfragments/$issue.bugfix` (for fixes) or `.feature` (for new features) or `.doc` (for documentation-only changes)
