### PR TITLE
Removing print statement

### DIFF
--- a/rs/src/interpreter/evaluator.rs
+++ b/rs/src/interpreter/evaluator.rs
@@ -259,7 +259,6 @@ fn slice(context: &Context, v: &Node, a: Option<&Node>, b: Option<&Node>) -> Res
 
         _ => unreachable!(),
     });
-    println!("r: {:?}", r);
     r
 }
 


### PR DESCRIPTION
This commit addresses an issue where an arbitrary line was being injected into the standard output stream. This causes problems for command line tools that rely on pipes to communicate with each other. By removing this line, we ensure proper communication and maintain the integrity of our pipeline.
