### PR TITLE
Add a `$reduce` operator

### DIFF
--- a/docs/src/operators.md
+++ b/docs/src/operators.md
@@ -240,7 +240,7 @@ result: {ax: 2, bx: 3, cx: 4}
 ## `$reduce`
 
 The `$reduce` operator evaluates an expression with each value of the given array and
-the result of the prior expression, reducing the array or object into a single JSON value.
+the result of the prior expression, reducing the array into a single JSON value.
 
 This operation is sometimes called `fold`, `accumulate`, `aggregate`, or `inject`.
 

--- a/docs/src/operators.md
+++ b/docs/src/operators.md
@@ -239,10 +239,10 @@ result: {ax: 2, bx: 3, cx: 4}
 
 ## `$reduce`
 
-The `$reduce` operator evaluates an expression with each value of the given array or object and
+The `$reduce` operator evaluates an expression with each value of the given array and
 the result of the prior expression, reducing the array or object into a single JSON value.
 
-This operation is sometimes called `fold`, `accumulate`, `aggregate`, `reduce`, or `inject`.
+This operation is sometimes called `fold`, `accumulate`, `aggregate`, or `inject`.
 
 An initial result is passed as the accumulator for the first evaluation of the expression.
 

--- a/docs/src/operators.md
+++ b/docs/src/operators.md
@@ -131,6 +131,7 @@ template: {$fromNow: '1 hour', from: '2017-01-19T16:27:20.974Z'}
 context:  {}
 result:   '2017-01-19T17:27:20.974Z'
 ```
+
 The available units, including useful shorthands, are:
 
 ```none
@@ -234,6 +235,38 @@ template:
   each(y): {'${y.key}x': {$eval: 'y.val + 1'}}
 context:  {}
 result: {ax: 2, bx: 3, cx: 4}
+```
+
+## `$reduce`
+
+The `$reduce` operator evaluates an expression with each value of the given array or object and
+the result of the prior expression, reducing the array or object into a single JSON value.
+
+This operation is sometimes called `fold`, `accumulate`, `aggregate`, `reduce`, or `inject`.
+
+An initial result is passed as the accumulator for the first evaluation of the expression.
+
+The `each` function defines the accumulated, or prior result, and the current value.  The result of
+this function will be passed as the accumulated to the next call of `each`.
+
+```yaml,json-e
+template:
+  $reduce: [{name: Apple, price: 1}, {name: Orange, price: 0.75}, {name: Pear, price: 1.1}]
+  initial: 0
+  each(acc, v): {$eval: 'acc + v.price'}
+context:  {}
+result:   2.85
+```
+
+The `each` function can define three variables, in which case the third is the 0-based index of the element.
+
+```yaml,json-e
+template:
+  $reduce: [2, 5, 8]
+  initial: 0
+  each(acc, v, i): {$eval: 'acc + v * 10 ** i'}
+context:  {}
+result:   852
 ```
 
 ## `$find`
@@ -420,6 +453,7 @@ result:   [{a: 1, b: []}, {a: 2}, {a: 3}]
 ```
 
 The sort is stable:
+
 ```yaml,json-e
 template:
   $sort: ["aa", "dd", "ac", "ba", "ab"]

--- a/py/jsone/newsfragments/+reduce.feature
+++ b/py/jsone/newsfragments/+reduce.feature
@@ -1,0 +1,1 @@
+Introduces the `$reduce` operator which combines an array or object into a single value.

--- a/specification.yml
+++ b/specification.yml
@@ -1213,6 +1213,125 @@ result:
     v: 'before=2'
 ################################################################################
 ---
+section: $reduce operator
+---
+title:    reduce array into number
+context:  {}
+template:
+  $reduce: [2, 4, 6]
+  each(acc, x): {$eval: 'acc + x'}
+  initial: 0
+result:   12
+---
+title:    reduce array with indexes into number
+context:  {}
+template:
+  $reduce: [2, 4, 6]
+  each(acc, x, i): {$eval: 'acc + x * 10 ** i'}
+  initial: 0
+result:   642
+---
+title:    reduce array into string
+context:  {}
+template:
+  $reduce: [2, 4, 6]
+  each(acc, x): "${acc}${x}"
+  initial: 'pre '
+result:   'pre 246'
+---
+title:    reduce array into boolean
+context:  {}
+template:
+  $reduce: [2, 4, 6]
+  each(acc, x): {$eval: 'acc || x > 5'}
+  initial: false
+result:   true
+---
+title:    reduce array into object
+# This is a contrived example since using $merge and $map would be more appropriate.
+# But it demonstrates that the accumulator can be an object
+context:  {}
+template:
+  $reduce: [2, 4, 6]
+  each(acc, x, i):
+    $merge: [{$eval: 'acc'}, {'k${i}': {$eval: 'x'}}]
+  initial: {a: 0}
+result: { a: 0, k0: 2, k1: 4, k2: 6 }
+---
+title:    reduce over an object
+context:  {}
+template:
+  $reduce: {a: 2, b: 4, c: 6}
+  each(acc, v, k): {$eval: 'acc + v'}
+  initial: 0
+error:   'TemplateError: $reduce value must evaluate to an array'
+---
+title:    reduce skips delete-marker from $if
+context:  {}
+template:
+  $reduce: [2, 4, 6]
+  initial: 0
+  each(acc, v, i):
+    $if: 'v != 4'
+    then: {$eval: 'acc + v'}
+result: 8
+---
+title:    reduce with undefined properties
+context:  {}
+template:
+  $reduce: [2, 4, 6]
+  each(acc, x): {$eval: 'acc + x'}
+  initial: 0
+  foo: 'bar'
+error:    'TemplateError: $reduce has undefined properties: foo'
+---
+title:    reduce with missing initial
+context:  {}
+template:
+  $reduce: [2, 4, 6]
+  each(acc, x): {$eval: 'acc + x'}
+error:    'TemplateError: $reduce must have exactly three properties'
+---
+title:    reduce with missing initial with undefined properties
+context:  {}
+template:
+  $reduce: [2, 4, 6]
+  each(acc, x): {$eval: 'acc + x'}
+  init: 9
+error:    'TemplateError: $reduce has undefined properties: init'
+---
+title:    reduce with missing each
+context:  {}
+template:
+  $reduce: [2, 4, 6]
+  initial: 0
+error:    'TemplateError: $reduce must have exactly three properties'
+---
+title:    reduce with missing each with undefined properties
+context:  {}
+template:
+  $reduce: [2, 4, 6]
+  each: 'acc + x'
+  initial: 0
+error:    'TemplateError: $reduce has undefined properties: each'
+---
+title:    reduce over a number
+context:  {}
+template:
+  $reduce: 10
+  each(acc, x): {$eval: 'acc + x'}
+  initial: 0
+error:    'TemplateError: $reduce value must evaluate to an array'
+---
+title:    reduce over a string
+context:  {}
+template:
+  $reduce: A Thing that is a String
+  each(acc, x): {$eval: 'acc + x'}
+  initial: 0
+error:    'TemplateError: $reduce value must evaluate to an array'
+---
+################################################################################
 section: $find operator
 ---
 title:   $find, simple find


### PR DESCRIPTION
This adds a `$reduce` operator.  It is somewhat similar to the `$merge` operator expect that it can produce any valid JSON type, not just objects. (Maybe more like nesting `$merge` and `$map`)

As a simple example:
```yaml
$reduce: [2, 4, 6]
each(acc, x): "${acc}${x}"
initial: 'pre '
```

Will output: `pre 246`

I am submitting this as a draft for now because:
1. I would like some feedback on this operator.
2. ~Only some versions are implemented.~
3. ~No docs yet.~

# Checklist

Before submitting a pull request, please check the following:

* [X] All tests pass for you on your machine for all implementations (all implementations must behave identically)
* [X] New tests have been added for any new functionality or to prevent regressions of a bugfix
* [x] Added a short description of the change to `newsfragments/$issue.bugfix` (for fixes) or `.feature` (for new features) or `.doc` (for documentation-only changes)
