### PR TITLE
Introducing `range` builtin

### DIFF
--- a/docs/src/built-ins.md
+++ b/docs/src/built-ins.md
@@ -148,13 +148,29 @@ The `range()` built-in generates an array based on the following inputs:
   this negative value (exclusive).
 * `step` - Optional. An integer specifying a step to apply to each value within
   the range. If not specified, defaults to `1`. Can be negative, but cannot be
-  zero.
-    * For a positive step, the contents of a range r are determined by the
-      formula `r[i] = start + step*i` where `i >= 0` and `r[i] < end`. The
-      resulting range will be empty if `start` >= `end`.
-    * For a negative step, the contents of the range are still determined by the
-      formula `r[i] = start + step*i`, where `i >= 0` and `r[i] > end`. The
-      resulting range will be empty if `start` <= `end`.
+  zero. The contents of a range r are determined by the following formula:
+  ```
+  IF step > 0 THEN
+
+    i = start
+    WHILE i < end:
+      r(i) = i
+      i = i + step
+    END WHILE
+
+  ELSE if step < 0 THEN
+
+    i = start
+    WHILE i > end:
+      r(i) = i
+      i = i + step
+    END WHILE
+
+  END IF
+  ```
+
+Notably, the resulting range will be empty if `start >= end` and `step` is
+positive or if `start` <= `end` and `step` is negative.
 
 ```yaml,json-e
 template:

--- a/docs/src/built-ins.md
+++ b/docs/src/built-ins.md
@@ -153,7 +153,7 @@ r[i] = start + step*i where i >= 0 and r[i] < end.
 For a negative step, the contents of the range are still determined by the
 formula r[i] = start + step*i, where i >= 0 and r[i] > end.
 
-```
+```yaml,json-e
 template:
   $map: {$eval: 'range(1, 5)'}
   each(x): {$eval: 'x'}

--- a/docs/src/built-ins.md
+++ b/docs/src/built-ins.md
@@ -148,29 +148,31 @@ The `range()` built-in generates an array based on the following inputs:
   this negative value (exclusive).
 * `step` - Optional. An integer specifying a step to apply to each value within
   the range. If not specified, defaults to `1`. Can be negative, but cannot be
-  zero. The contents of a range r are determined by the following formula:
-  ```
-  IF step > 0 THEN
+  zero.
 
-    i = start
-    WHILE i < end:
-      r(i) = i
-      i = i + step
-    END WHILE
+The contents of a range r are determined by the following formula:
+```
+IF step > 0 THEN
 
-  ELSE if step < 0 THEN
+  i = start
+  WHILE i < end:
+    r(i) = i
+    i = i + step
+  END WHILE
 
-    i = start
-    WHILE i > end:
-      r(i) = i
-      i = i + step
-    END WHILE
+ELSE if step < 0 THEN
 
-  END IF
-  ```
+  i = start
+  WHILE i > end:
+    r(i) = i
+    i = i + step
+  END WHILE
+
+END IF
+```
 
 Notably, the resulting range will be empty if `start >= end` and `step` is
-positive or if `start` <= `end` and `step` is negative.
+positive or if `start <= end` and `step` is negative.
 
 ```yaml,json-e
 template:

--- a/docs/src/built-ins.md
+++ b/docs/src/built-ins.md
@@ -136,3 +136,27 @@ template: {$eval: 'len([1, 2, 3])'}
 context: {}
 result: 3
 ```
+
+## Range
+
+The `range()` built-in generates an array based on the following inputs:
+* `start` - An integer specifying the lower bound of the range (inclusive).
+  This can be negative.
+* `end` - An integer specifying the upper bound of the range (exclusive). This
+  can be negative.
+* `step` - Optional. An integer specifying a step to apply to each value within
+  the range. If not specified, defaults to `1`. Can be negative.
+
+For a positive step, the contents of a range r are determined by the formula
+r[i] = start + step*i where i >= 0 and r[i] < end.
+
+For a negative step, the contents of the range are still determined by the
+formula r[i] = start + step*i, where i >= 0 and r[i] > end.
+
+```
+template:
+  $map: {$eval: 'range(1, 5)'}
+  each(x): {$eval: 'x'}
+context:  {}
+result:   [1, 2, 3, 4]
+```

--- a/docs/src/built-ins.md
+++ b/docs/src/built-ins.md
@@ -141,17 +141,20 @@ result: 3
 
 The `range()` built-in generates an array based on the following inputs:
 * `start` - An integer specifying the lower bound of the range (inclusive).
-  This can be negative.
+  This can be negative, in which case the generated array of integers will
+  start with this negative value (inclusive).
 * `end` - An integer specifying the upper bound of the range (exclusive). This
-  can be negative.
+  can be negative, in which case the generated array of integers will end with
+  this negative value (exclusive).
 * `step` - Optional. An integer specifying a step to apply to each value within
-  the range. If not specified, defaults to `1`. Can be negative.
-
-For a positive step, the contents of a range r are determined by the formula
-r[i] = start + step*i where i >= 0 and r[i] < end.
-
-For a negative step, the contents of the range are still determined by the
-formula r[i] = start + step*i, where i >= 0 and r[i] > end.
+  the range. If not specified, defaults to `1`. Can be negative, but cannot be
+  zero.
+    * For a positive step, the contents of a range r are determined by the
+      formula `r[i] = start + step*i` where `i >= 0` and `r[i] < end`. The
+      resulting range will be empty if `start` >= `end`.
+    * For a negative step, the contents of the range are still determined by the
+      formula `r[i] = start + step*i`, where `i >= 0` and `r[i] > end`. The
+      resulting range will be empty if `start` <= `end`.
 
 ```yaml,json-e
 template:

--- a/docs/src/built-ins.md
+++ b/docs/src/built-ins.md
@@ -151,7 +151,8 @@ The `range()` built-in generates an array based on the following inputs:
   zero.
 
 The contents of a range r are determined by the following formula:
-```
+
+```yaml,json-e
 IF step > 0 THEN
 
   i = start

--- a/internal/interpreter/util.go
+++ b/internal/interpreter/util.go
@@ -22,6 +22,11 @@ func isBool(v interface{}) bool {
 	return ok
 }
 
+func IsInteger(v interface{}) bool {
+	floatRep, _ := v.(float64)
+	return floatRep == float64(int(floatRep))
+}
+
 // IsJSON returns true, if v is pure JSON
 func IsJSON(v interface{}) bool {
 	if isString(v) || isNumber(v) || isBool(v) || v == nil {
@@ -53,15 +58,11 @@ func IsTruthy(v interface{}) bool {
 		return false
 	case []interface{}:
 		return len(val) > 0
-	case []int:
-		return len(val) > 0
 	case map[string]interface{}:
 		return len(val) > 0
 	case string:
 		return len(val) > 0
 	case float64:
-		return val != 0
-	case int:
 		return val != 0
 	case bool:
 		return val
@@ -79,13 +80,11 @@ type function struct {
 
 var allowedTypes = []reflect.Type{
 	reflect.TypeOf(float64(0)),
-	reflect.TypeOf(int(0)),
 	reflect.TypeOf(""),
 	reflect.TypeOf(true),
 	reflect.TypeOf((*interface{})(nil)).Elem(),
 	reflect.TypeOf([]interface{}(nil)),
 	reflect.TypeOf(map[string]interface{}(nil)),
-	reflect.TypeOf([]int(nil)),
 }
 
 var typeOfError = reflect.TypeOf((*error)(nil)).Elem()
@@ -153,7 +152,7 @@ func wrapFunction(f interface{}, withContext bool) (interface{}, error) {
 			}
 		}
 		if !ok {
-			return nil, injectedFunctionError(f, "may only accept: bool, string, float64, int, []int, []interface{}, map[string]interface{} and interface{}")
+			return nil, injectedFunctionError(f, "may only accept: bool, string, float64, []interface{}, map[string]interface{} and interface{}")
 		}
 	}
 	// Check return values
@@ -248,16 +247,9 @@ func IsValidData(data interface{}) error {
 		return nil
 	}
 	switch val := data.(type) {
-	case *function, string, float64, bool, int:
+	case *function, string, float64, bool:
 		return nil
 	case []interface{}:
-		for _, value := range val {
-			if err := IsValidData(value); err != nil {
-				return err
-			}
-		}
-		return nil
-	case []int:
 		for _, value := range val {
 			if err := IsValidData(value); err != nil {
 				return err

--- a/internal/interpreter/util.go
+++ b/internal/interpreter/util.go
@@ -53,11 +53,15 @@ func IsTruthy(v interface{}) bool {
 		return false
 	case []interface{}:
 		return len(val) > 0
+	case []int:
+		return len(val) > 0
 	case map[string]interface{}:
 		return len(val) > 0
 	case string:
 		return len(val) > 0
 	case float64:
+		return val != 0
+	case int:
 		return val != 0
 	case bool:
 		return val
@@ -75,11 +79,13 @@ type function struct {
 
 var allowedTypes = []reflect.Type{
 	reflect.TypeOf(float64(0)),
+	reflect.TypeOf(int(0)),
 	reflect.TypeOf(""),
 	reflect.TypeOf(true),
 	reflect.TypeOf((*interface{})(nil)).Elem(),
 	reflect.TypeOf([]interface{}(nil)),
 	reflect.TypeOf(map[string]interface{}(nil)),
+	reflect.TypeOf([]int(nil)),
 }
 
 var typeOfError = reflect.TypeOf((*error)(nil)).Elem()
@@ -147,7 +153,7 @@ func wrapFunction(f interface{}, withContext bool) (interface{}, error) {
 			}
 		}
 		if !ok {
-			return nil, injectedFunctionError(f, "may only accept: bool, string, float64, []interface{}, map[string]interface{} and interface{}")
+			return nil, injectedFunctionError(f, "may only accept: bool, string, float64, int, []int, []interface{}, map[string]interface{} and interface{}")
 		}
 	}
 	// Check return values
@@ -242,9 +248,16 @@ func IsValidData(data interface{}) error {
 		return nil
 	}
 	switch val := data.(type) {
-	case *function, string, float64, bool:
+	case *function, string, float64, bool, int:
 		return nil
 	case []interface{}:
+		for _, value := range val {
+			if err := IsValidData(value); err != nil {
+				return err
+			}
+		}
+		return nil
+	case []int:
 		for _, value := range val {
 			if err := IsValidData(value); err != nil {
 				return err

--- a/internal/jsone.go
+++ b/internal/jsone.go
@@ -157,10 +157,27 @@ var builtin = map[string]interface{}{
 		}
 		return n
 	}),
-	"sqrt":      i.WrapFunction(math.Sqrt),
-	"ceil":      i.WrapFunction(math.Ceil),
-	"floor":     i.WrapFunction(math.Floor),
-	"abs":       i.WrapFunction(math.Abs),
+	"sqrt":  i.WrapFunction(math.Sqrt),
+	"ceil":  i.WrapFunction(math.Ceil),
+	"floor": i.WrapFunction(math.Floor),
+	"abs":   i.WrapFunction(math.Abs),
+	"range": i.WrapFunction(
+		func(start float64, stop float64, args ...float64) ([]interface{}, error) {
+			var result []interface{}
+			step := 1
+			if len(args) != 0 && len(args) > 1 {
+				return result, fmt.Errorf("range(start, stop, step) requires start and stop argument and optionally takes step")
+			}
+			if len(args) == 1 {
+				step = int(args[0])
+			}
+
+			for i := int(start); i < int(stop); i += step {
+				result = append(result, float64(i))
+			}
+			return result, nil
+		},
+	),
 	"lowercase": i.WrapFunction(strings.ToLower),
 	"uppercase": i.WrapFunction(strings.ToUpper),
 	"strip":     i.WrapFunction(strings.TrimSpace),

--- a/js/src/builtins.js
+++ b/js/src/builtins.js
@@ -38,7 +38,7 @@ module.exports = (context) => {
       }
 
       if (variadic) {
-        argumentTests = args.map(() => variadic);
+        argumentTests = args.map((_, i) => i < argumentTests.length ? argumentTests[i] : variadic);
       }
 
       args.forEach((arg, i) => {
@@ -76,6 +76,18 @@ module.exports = (context) => {
       argumentTests: ['number'],
       invoke: num => Math[name](num),
     });
+  });
+
+  define('range', builtins, {
+    minArgs: 2,
+    argumentTests: ['number', 'number'],
+    variadic: 'number',
+    invoke: (start, stop, step=1) => {
+      return Array.from(
+        {length: Math.ceil((stop - start) / step)}, 
+        (_, i) => start + i * step
+      )
+    },
   });
 
   // String manipulation

--- a/js/src/builtins.js
+++ b/js/src/builtins.js
@@ -2,13 +2,14 @@ var {BuiltinError} = require('./error');
 var fromNow = require('./from-now');
 var {
   isString, isNumber, isBool,
-  isArray, isObject,
+  isInteger, isArray, isObject,
   isNull, isFunction,
 } = require('./type-utils');
 
 let types = {
   string: isString,
   number: isNumber,
+  integer: isInteger,
   boolean: isBool,
   array: isArray,
   object: isObject,
@@ -80,7 +81,7 @@ module.exports = (context) => {
 
   define('range', builtins, {
     minArgs: 2,
-    argumentTests: ['number', 'number'],
+    argumentTests: ['integer', 'integer', 'integer'],
     variadic: 'number',
     invoke: (start, stop, step=1) => {
       return Array.from(

--- a/py/jsone/builtins.py
+++ b/py/jsone/builtins.py
@@ -66,6 +66,9 @@ def build():
     def is_number(v):
         return isinstance(v, (int, float)) and not isinstance(v, bool)
 
+    def is_number_or_none(v):
+        return is_number(v) or v is None
+
     def is_string(v):
         return isinstance(v, string)
 
@@ -100,6 +103,11 @@ def build():
     @builtin("floor", argument_tests=[is_number])
     def floor(v):
         return int(math.floor(v))
+
+    @builtin("range", minArgs=2)
+    def range_builtin(start, stop, step=1):
+        print(f"initiating range with {start}, {stop}, {step}")
+        return list(range(start, stop, step))
 
     @builtin("lowercase", argument_tests=[is_string])
     def lowercase(v):

--- a/py/jsone/builtins.py
+++ b/py/jsone/builtins.py
@@ -66,6 +66,9 @@ def build():
     def is_number(v):
         return isinstance(v, (int, float)) and not isinstance(v, bool)
 
+    def is_int(v):
+        return isinstance(v, int)
+
     def is_string(v):
         return isinstance(v, string)
 
@@ -103,6 +106,9 @@ def build():
 
     @builtin("range", minArgs=2)
     def range_builtin(start, stop, step=1):
+        if step == 0 or not all([is_int(n) for n in [start, stop, step]]):
+            raise BuiltinError("invalid arguments to builtin: range")
+
         return list(range(start, stop, step))
 
     @builtin("lowercase", argument_tests=[is_string])

--- a/py/jsone/builtins.py
+++ b/py/jsone/builtins.py
@@ -66,9 +66,6 @@ def build():
     def is_number(v):
         return isinstance(v, (int, float)) and not isinstance(v, bool)
 
-    def is_number_or_none(v):
-        return is_number(v) or v is None
-
     def is_string(v):
         return isinstance(v, string)
 
@@ -106,7 +103,6 @@ def build():
 
     @builtin("range", minArgs=2)
     def range_builtin(start, stop, step=1):
-        print(f"initiating range with {start}, {stop}, {step}")
         return list(range(start, stop, step))
 
     @builtin("lowercase", argument_tests=[is_string])

--- a/rs/src/builtins.rs
+++ b/rs/src/builtins.rs
@@ -190,8 +190,8 @@ fn strip_builtin(_context: &Context, args: &[Value]) -> Result<Value> {
 }
 
 fn range_builtin(_context: &Context, args: &[Value]) -> Result<Value> {
-   if args.len() != 2 {
-        return Err(interpreter_error!("range expects two arguments"));
+   if args.len() < 2 || args.len() > 3 {
+        return Err(interpreter_error!("range requires two arguments and optionally supports a third"));
     }
     let start = &args[0];
     let start: i64 = match start {
@@ -203,7 +203,16 @@ fn range_builtin(_context: &Context, args: &[Value]) -> Result<Value> {
         Value::Number(n) => n.round() as i64,
         _ => return Err(interpreter_error!("invalid arguments to builtin: range")),
     };
-    let range = (start..stop).map(|i| Value::Number(i as f64)).collect();
+    let step: usize = match args.get(2) {
+        // If step is not provided by the user, it defaults to 1.
+        None => 1,
+        Some(val) => match val {
+            Value::Number(n) => n.round() as usize,
+            _ => return Err(interpreter_error!("invalid arguments to builtin: range")),
+        }
+    };
+
+    let range = (start..stop).step_by(step).map(|i| Value::Number(i as f64)).collect();
     Ok(Value::Array(range))
 }
 

--- a/rs/src/builtins.rs
+++ b/rs/src/builtins.rs
@@ -3,6 +3,7 @@ use crate::interpreter::Context;
 use crate::value::{Function, Value};
 use anyhow::Result;
 use lazy_static::lazy_static;
+use std::convert::TryInto;
 
 lazy_static! {
     pub(crate) static ref BUILTINS: Context<'static> = {
@@ -213,11 +214,11 @@ fn range_builtin(_context: &Context, args: &[Value]) -> Result<Value> {
     };
 
     if step > 0 {
-        let step = step as usize;
+        let step: usize = step.try_into()?;
         let range = (start..stop).step_by(step).map(|i| Value::Number(i as f64)).collect();
         Ok(Value::Array(range))
     } else if step < 0 {
-        let step = (step * -1) as usize;
+        let step: usize = (step * -1).try_into()?;
         let range = (stop+1..=start).rev().step_by(step).map(|i| Value::Number(i as f64)).collect();
         Ok(Value::Array(range))
     } else {

--- a/rs/src/builtins.rs
+++ b/rs/src/builtins.rs
@@ -34,6 +34,7 @@ lazy_static! {
             "strip",
             Value::Function(Function::new("strip", strip_builtin)),
         );
+        builtins.insert("range", Value::Function(Function::new("range", range_builtin)));
         builtins.insert(
             "rstrip",
             Value::Function(Function::new("rstrip", rstrip_builtin)),
@@ -186,6 +187,24 @@ fn number_builtin(_context: &Context, args: &[Value]) -> Result<Value> {
 
 fn strip_builtin(_context: &Context, args: &[Value]) -> Result<Value> {
     unary_string(args, |s| str::trim(s).to_owned())
+}
+
+fn range_builtin(_context: &Context, args: &[Value]) -> Result<Value> {
+   if args.len() != 2 {
+        return Err(interpreter_error!("range expects two arguments"));
+    }
+    let start = &args[0];
+    let start: i64 = match start {
+        Value::Number(n) => n.round() as i64,
+        _ => return Err(interpreter_error!("invalid arguments to builtin: range")),
+    };
+    let stop = &args[1];
+    let stop: i64 = match stop {
+        Value::Number(n) => n.round() as i64,
+        _ => return Err(interpreter_error!("invalid arguments to builtin: range")),
+    };
+    let range = (start..stop).map(|i| Value::Number(i as f64)).collect();
+    Ok(Value::Array(range))
 }
 
 fn rstrip_builtin(_context: &Context, args: &[Value]) -> Result<Value> {

--- a/specification.yml
+++ b/specification.yml
@@ -1138,6 +1138,13 @@ template:
   each(x): {$eval: 'x'}
 result:   [-7, -8, -9]
 ---
+title:    range with negative step that does not divide evenly
+context:  {}
+template:
+  $map: {$eval: 'range(20, 0, -7)'}
+  each(x): {$eval: 'x'}
+result:   [20, 13, 6]
+---
 title:    range with step=0 throws error
 context:  {}
 template:

--- a/specification.yml
+++ b/specification.yml
@@ -1102,6 +1102,42 @@ template: {$map: {a: 1, b: 2, c: 3}, 'each(y)': {'${y.key}x': {$eval: 'y.val + 1
 result:   {ax: 2, bx: 3, cx: 4}
 ################################################################################
 ---
+section:  $range
+---
+title:    simple range without step creates list of numbers
+context:  {}
+template:
+  $map: {$eval: 'range(1, 5)'}
+  each(x): {$eval: 'x'}
+result:   [1, 2, 3, 4]
+---
+title:    simple range without step creates list of objects
+context:  {}
+template:
+  $map: {$eval: 'range(1, 4)'}
+  each(x):
+    asText: '${x}'
+    integer: {$eval: 'x'}
+result:
+ - {asText: '1', integer: 1}
+ - {asText: '2', integer: 2}
+ - {asText: '3', integer: 3}
+---
+title:    simple range without step creates list of strings
+context:  {}
+template:
+  $map: {$eval: 'range(10, 12)'}
+  each(x, i): 'id_${x}_${i}'
+result: ['id_10_0', 'id_11_1']
+---
+title:    simple range with step creates list of strings
+context:  {}
+template:
+  $map: {$eval: 'range(10, 20, 5)'}
+  each(x, i): 'id_${x}_${i}'
+result: ['id_10_0', 'id_15_1']
+################################################################################
+---
 section: $find operator
 ---
 title:   $find, simple find

--- a/specification.yml
+++ b/specification.yml
@@ -1111,12 +1111,61 @@ template:
   each(x): {$eval: 'x'}
 result:   [1, 2, 3, 4]
 ---
+title:    range with end > start creates empty list
+context:  {}
+template:
+  $map: {$eval: 'range(5, 1)'}
+  each(x): {$eval: 'x'}
+result:   []
+---
 title:    range with step creates list of numbers
 context:  {}
 template:
   $map: {$eval: 'range(1, 10, 2)'}
   each(x): {$eval: 'x'}
 result:   [1, 3, 5, 7, 9]
+---
+title:    range with negative step creates list of numbers
+context:  {}
+template:
+  $map: {$eval: 'range(1, -2, -1)'}
+  each(x): {$eval: 'x'}
+result:   [1, 0, -1]
+---
+title:    range with negative step and negative start and end creates list of numbers
+context:  {}
+template:
+  $map: {$eval: 'range(-7, -10, -1)'}
+  each(x): {$eval: 'x'}
+result:   [-7, -8, -9]
+---
+title:    range with step=0 throws error
+context:  {}
+template:
+  $map: {$eval: 'range(1, 5, 0)'}
+  each(x): {$eval: 'x'}
+error: true
+---
+title:    range with float step throws error
+context:  {}
+template:
+  $map: {$eval: 'range(1, 5, 1.2)'}
+  each(x): {$eval: 'x'}
+error: true
+---
+title:    range with float start throws error
+context:  {}
+template:
+  $map: {$eval: 'range(1.3, 5)'}
+  each(x): {$eval: 'x'}
+error: true
+---
+title:    range with string start throws error
+context:  {}
+template:
+  $map: {$eval: 'range("1", 5)'}
+  each(x): {$eval: 'x'}
+error: true
 ---
 title:    range without step creates list of objects
 context:  {}

--- a/specification.yml
+++ b/specification.yml
@@ -1134,14 +1134,14 @@ title:    range without step creates list of strings
 context:  {}
 template:
   $map: {$eval: 'range(10, 12)'}
-  each(x, i): 'id_${x}_${i}'
+  each(x,i): 'id_${x}_${i}'
 result: ['id_10_0', 'id_11_1']
 ---
 title:    range with step creates list of strings
 context:  {}
 template:
   $map: {$eval: 'range(10, 20, 5)'}
-  each(x, i): 'id_${x}_${i}'
+  each(x,i): 'id_${x}_${i}'
 result: ['id_10_0', 'id_15_1']
 ---
 title:    range without step creates objects

--- a/specification.yml
+++ b/specification.yml
@@ -1104,14 +1104,21 @@ result:   {ax: 2, bx: 3, cx: 4}
 ---
 section:  $range
 ---
-title:    simple range without step creates list of numbers
+title:    range without step creates list of numbers
 context:  {}
 template:
   $map: {$eval: 'range(1, 5)'}
   each(x): {$eval: 'x'}
 result:   [1, 2, 3, 4]
 ---
-title:    simple range without step creates list of objects
+title:    range with step creates list of numbers
+context:  {}
+template:
+  $map: {$eval: 'range(1, 10, 2)'}
+  each(x): {$eval: 'x'}
+result:   [1, 3, 5, 7, 9]
+---
+title:    range without step creates list of objects
 context:  {}
 template:
   $map: {$eval: 'range(1, 4)'}
@@ -1123,19 +1130,32 @@ result:
  - {asText: '2', integer: 2}
  - {asText: '3', integer: 3}
 ---
-title:    simple range without step creates list of strings
+title:    range without step creates list of strings
 context:  {}
 template:
   $map: {$eval: 'range(10, 12)'}
   each(x, i): 'id_${x}_${i}'
 result: ['id_10_0', 'id_11_1']
 ---
-title:    simple range with step creates list of strings
+title:    range with step creates list of strings
 context:  {}
 template:
   $map: {$eval: 'range(10, 20, 5)'}
   each(x, i): 'id_${x}_${i}'
 result: ['id_10_0', 'id_15_1']
+---
+title:    range without step creates objects
+context:  {}
+template:
+  $map: {$eval: 'range(1, 3)'}
+  each(y):
+    k: {$eval: 'y + 1'}
+    v: 'before=${y}'
+result:
+  - k: 2
+    v: 'before=1'
+  - k: 3
+    v: 'before=2'
 ################################################################################
 ---
 section: $find operator

--- a/specification.yml
+++ b/specification.yml
@@ -1102,7 +1102,7 @@ template: {$map: {a: 1, b: 2, c: 3}, 'each(y)': {'${y.key}x': {$eval: 'y.val + 1
 result:   {ax: 2, bx: 3, cx: 4}
 ################################################################################
 ---
-section:  $range
+section:  range
 ---
 title:    range without step creates list of numbers
 context:  {}
@@ -1114,9 +1114,8 @@ result:   [1, 2, 3, 4]
 title:    range with end > start creates empty list
 context:  {}
 template:
-  $map: {$eval: 'range(5, 1)'}
-  each(x): {$eval: 'x'}
-result:   []
+  {$eval: 'len(range(5, 1))'}
+result:   0
 ---
 title:    range with step creates list of numbers
 context:  {}


### PR DESCRIPTION
# Summary
Implements a new builtin `range` function. See discussion in https://github.com/json-e/json-e/issues/532 for background.

# Details
* Implements support for a new builtin `range` function in javascript, python, rust, golang
* Adds tests in `specification.yml`
* Updates documentation to refer to functionality for the new function