### PR TITLE
Test and fix handling of false-y $default in $switch

### DIFF
--- a/internal/jsone.go
+++ b/internal/jsone.go
@@ -920,16 +920,17 @@ var operators = map[string]operator{
 			}
 		}
 
-		if len(result) == 0 && match["$default"] != nil {
-			value := match["$default"]
-			r, err := render(value, context)
-			if err != nil {
-				return nil, TemplateError{
-					Message:  err.Error(),
-					Template: template,
+		if len(result) == 0 {
+			if value, ok := match["$default"]; ok {
+				r, err := render(value, context)
+				if err != nil {
+					return nil, TemplateError{
+						Message:  err.Error(),
+						Template: template,
+					}
 				}
+				result = append(result, r)
 			}
-			result = append(result, r)
 		}
 
 		if len(result) == 0 {

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -326,7 +326,7 @@ operators.$switch = (template, context) => {
     throw new TemplateError('$switch can only have one truthy condition');
   }
 
-  if (result.length === 0 && conditions[ '$default' ]) {
+  if (result.length === 0 && "$default" in conditions) {
     result.push(render(conditions[ '$default' ], context));
   }
 

--- a/py/jsone/newsfragments/541.bugfix
+++ b/py/jsone/newsfragments/541.bugfix
@@ -1,0 +1,1 @@
+Fix handling of false-y $default values in $switch in JS and Go implementations.

--- a/specification.yml
+++ b/specification.yml
@@ -1543,6 +1543,46 @@ title:    $switch, $default with 1 match in object
 context:  {cond: 3}
 template: {$switch: {'cond == 3': 1, $default: 'fallback'}}
 result:   1
+---
+title:    $switch, $default of empty string
+context:  {}
+template: {$switch: {'false': 1, $default: ''}}
+result:   ''
+---
+title:    $switch, $default of empty string not a deletion marker
+context:  {}
+template: [{$switch: {'false': 1, $default: ''}}]
+result:   ['']
+---
+title:    $switch, $default of false
+context:  {}
+template: {$switch: {'false': 1, $default: false}}
+result:   false
+---
+title:    $switch, $default of false not a deletion marker
+context:  {}
+template: [{$switch: {'false': 1, $default: false}}]
+result:   [false]
+---
+title:    $switch, $default of null
+context:  {}
+template: {$switch: {'false': 1, $default: null}}
+result:   null
+---
+title:    $switch, $default of null not a deletion marker
+context:  {}
+template: [{$switch: {'false': 1, $default: null}}]
+result:   [null]
+---
+title:    $switch, $default of 0
+context:  {}
+template: {$switch: {'false': 1, $default: 0}}
+result:   0
+---
+title:    $switch, $default of 0 not a deletion marker
+context:  {}
+template: [{$switch: {'false': 1, $default: 0}}]
+result:   [0]
 ###############################################################################
 ---
 section:  $merge


### PR DESCRIPTION
Tests revealed subtle failures here in both Go and JS. These bugs are unlikely to be relied on, so can be fixed at a bug-fix level.

Fixes #541.