### PR TITLE
fix $switch example

### DIFF
--- a/docs/src/operators.md
+++ b/docs/src/operators.md
@@ -395,7 +395,7 @@ result:   [0]
 ```yaml,json-e
 template: [0, {$switch: {'cond > 3': 2, 'cond == 5': 3, $default: 4}}]
 context:  {cond: 1}
-result:   [4]
+result:   [0, 4]
 ```
 
 ## `$merge`


### PR DESCRIPTION
There was an incorrect example for the $switch operator.

I've validated the correct answer using the playground
![Screenshot 2025-05-22 at 00 13 26](https://github.com/user-attachments/assets/0e0884b3-ba11-4915-b601-112619c7c4fc)



# Checklist

Before submitting a pull request, please check the following:

* [x] All tests pass for you on your machine for all implementations (all implementations must behave identically)
* [ ] New tests have been added for any new functionality or to prevent regressions of a bugfix
* [ ] Added a short description of the change to `newsfragments/$issue.bugfix` (for fixes) or `.feature` (for new features) or `.doc` (for documentation-only changes)
