### PR TITLE
Rust: avoid panicking on non finite float

### DIFF
--- a/py/jsone/newsfragments/555.bugfix
+++ b/py/jsone/newsfragments/555.bugfix
@@ -1,0 +1,1 @@
+The Rust version no longer panics when it encounters a non-finite float.

--- a/rs/src/value.rs
+++ b/rs/src/value.rs
@@ -154,9 +154,9 @@ impl Value {
 fn f64_to_serde_number(value: f64) -> Result<Number> {
     if value.fract() == 0.0 {
         if value < 0.0 && value > -(u32::MAX as f64) {
-            return (value as i64).into();
+            return Ok((value as i64).into());
         } else if value >= 0.0 && value < u32::MAX as f64 {
-            return (value as u64).into();
+            return Ok((value as u64).into());
         }
     }
     // the failure conditions here are NaN and Infinity, which we do not see

--- a/rs/src/value.rs
+++ b/rs/src/value.rs
@@ -160,9 +160,8 @@ fn f64_to_serde_number(value: f64) -> Result<Number> {
         }
     }
     // the failure conditions here are NaN and Infinity, which we do not see
-    Number::from_f64(value).ok_or_else(|| {
-        template_error!("{} is not finite and cannot be represented in JSON")
-    })
+    Number::from_f64(value)
+        .ok_or_else(|| template_error!("{value} is not finite and cannot be represented in JSON"))
 }
 
 impl From<&Value> for bool {

--- a/rs/src/value.rs
+++ b/rs/src/value.rs
@@ -160,8 +160,7 @@ fn f64_to_serde_number(value: f64) -> Result<Number> {
         }
     }
     // the failure conditions here are NaN and Infinity, which we do not see
-    Number::from_f64(value)
-        .ok_or_else(|| template_error!("{value} is not finite and cannot be represented in JSON"))
+    Number::from_f64(value).ok_or_else(|| template_error!("{value} cannot be represented in JSON"))
 }
 
 impl From<&Value> for bool {


### PR DESCRIPTION
This function seems to panic when it receives a non finite value, which is hard to recover from. Since its caller already returns a result, I made the function return a result too.

# Checklist

Before submitting a pull request, please check the following:

* [x] All tests pass for you on your machine for all implementations (all implementations must behave identically)
* [ ] New tests have been added for any new functionality or to prevent regressions of a bugfix
* [x] Added a short description of the change to `newsfragments/$issue.bugfix` (for fixes) or `.feature` (for new features) or `.doc` (for documentation-only changes)

 I'll do these checklist items soon