### PR TITLE
Rust: Fix string interpolation in template error message for non finite numbers

### DIFF
--- a/py/jsone/newsfragments/558.bugfix
+++ b/py/jsone/newsfragments/558.bugfix
@@ -1,0 +1,1 @@
+The Rust error message when a non finite number is encountered now properly includes the non finite value, rather than {value}.

--- a/rs/src/value.rs
+++ b/rs/src/value.rs
@@ -160,7 +160,7 @@ fn f64_to_serde_number(value: f64) -> Result<Number> {
         }
     }
     // the failure conditions here are NaN and Infinity, which we do not see
-    Number::from_f64(value).ok_or_else(|| template_error!("{value} cannot be represented in JSON"))
+    Number::from_f64(value).ok_or_else(|| template_error!("{} cannot be represented in JSON", value))
 }
 
 impl From<&Value> for bool {


### PR DESCRIPTION
This fixes a bug I introduced in #555. When a non finite number gets produced (see example below), the Rust implementation's error message says `{value} cannot be represented in JSON`. This is because the `template_error!` macro, unlike `format!`, has a special case when there's only one argument and treats the argument string as a plain string.

# Checklist

Before submitting a pull request, please check the following:

* [x] All tests pass for you on your machine for all implementations (all implementations must behave identically)
  * I added a fake test to see the error output. It now says `inf` instead of `{value}`. I didn't test the other implementations since I only changed Rust code; hopefully that's fine!
    
    ```diff
    +---
    +title: 'bleh'
    +context: {}
    +template: {$let: {a: 1.7976931348623157e+308}, in: {$eval: 'a * 2'}}
    +result: 5
    ```
        
    ```
    ---- expression_language___errors_bleh stdout ----
    expression language - errors - bleh
    
    thread 'expression_language___errors_bleh' panicked at /Users/seyen/json-e/rs/target/debug/build/json-e-c65ebd27c155f4ae/out/test_spec.rs:12371:44:
    called `Result::unwrap()` on an `Err` value: TemplateError: inf cannot be represented in JSON
    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
    ```
* [ ] New tests have been added for any new functionality or to prevent regressions of a bugfix
  * It would be nice to add a test to specifications, but currently non finite values are handled differently in each implementation so testing the error message would make other implementations fail 
* [x] Added a short description of the change to `newsfragments/$issue.bugfix` (for fixes) or `.feature` (for new features) or `.doc` (for documentation-only changes)
