### PR TITLE
Fix repo cloning URLs in .taskcluster.yml

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -12,7 +12,7 @@ tasks:
     repo:
       $if: 'tasks_for == "github-push"'
       then:
-        url: ${event.repository.url}
+        url: ${event.repository.html_url}
         ref: ${event.after}
       else:
         url: ${event.pull_request.head.repo.html_url}


### PR DESCRIPTION
In April 2025, github changed [1] the push webhooks to return `https://api.github.com/repos/<org>/<repo>` instead of `https://github.com/<org>/<repo>`. This broke cloning this repo on CI since you cannot clone a repo from the first URL but can from the second. The solution is simply to use `event.repository.html_url` instead of `event.repository.url`.

[1]: https://github.blog/changelog/2025-04-07-changes-to-the-repository-object-in-push-webhook/
