### PR TITLE
Apply cargo clippy fixes

### DIFF
--- a/rs/build.rs
+++ b/rs/build.rs
@@ -75,19 +75,19 @@ fn main() {
 /// Convert the given Yaml value to a serde_json::Value
 fn to_json(y: &Yaml) -> Value {
     match y {
-        &Yaml::Real(ref v) => Value::Number(Number::from_str(v).unwrap()),
-        &Yaml::Integer(v) => Value::Number(v.into()),
-        &Yaml::String(ref v) => Value::String(v.into()),
-        &Yaml::Boolean(ref v) => Value::Bool(*v),
-        &Yaml::Array(ref v) => Value::Array(v.iter().map(|y| to_json(y)).collect()),
-        &Yaml::Hash(ref v) => Value::Object(
+        Yaml::Real(v) => Value::Number(Number::from_str(v).unwrap()),
+        Yaml::Integer(v) => Value::Number((*v).into()),
+        Yaml::String(v) => Value::String(v.into()),
+        Yaml::Boolean(v) => Value::Bool(*v),
+        Yaml::Array(v) => Value::Array(v.iter().map(to_json).collect()),
+        Yaml::Hash(v) => Value::Object(
             v.iter()
                 .map(|(k, v)| (k.as_str().unwrap().to_string(), to_json(v)))
                 .collect(),
         ),
-        &Yaml::Null => Value::Null,
-        &Yaml::Alias(_) => todo!(),
-        &Yaml::BadValue => todo!(),
+        Yaml::Null => Value::Null,
+        Yaml::Alias(_) => todo!(),
+        Yaml::BadValue => todo!(),
     }
 }
 
@@ -96,6 +96,7 @@ fn to_json_str(y: &Yaml) -> String {
     to_string(&to_json(y)).unwrap()
 }
 
+#[allow(clippy::too_many_arguments)]
 fn write_test(
     test_file: &mut File,
     test_names: &mut HashSet<String>,

--- a/rs/src/builtins.rs
+++ b/rs/src/builtins.rs
@@ -124,7 +124,7 @@ fn str_builtin(_context: &Context, args: &[Value]) -> Result<Value> {
 
     match v {
         Value::Null | Value::String(_) | Value::Number(_) | Value::Bool(_) => {
-            v.stringify().map(|s| Value::String(s))
+            v.stringify().map(Value::String)
         }
         _ => Err(interpreter_error!("invalid arguments to builtin: str")),
     }
@@ -218,11 +218,11 @@ fn range_builtin(_context: &Context, args: &[Value]) -> Result<Value> {
         let range = (start..stop).step_by(step).map(|i| Value::Number(i as f64)).collect();
         Ok(Value::Array(range))
     } else if step < 0 {
-        let step: usize = (step * -1).try_into()?;
+        let step: usize = (-step).try_into()?;
         let range = (stop+1..=start).rev().step_by(step).map(|i| Value::Number(i as f64)).collect();
         Ok(Value::Array(range))
     } else {
-        return Err(interpreter_error!("invalid argument `step` to builtin: range"));
+        Err(interpreter_error!("invalid argument `step` to builtin: range"))
     }
 }
 
@@ -248,7 +248,7 @@ fn join_builtin(_context: &Context, args: &[Value]) -> Result<Value> {
 
     match v {
         Value::Array(v) => {
-            let strings: Result<Vec<String>> = v.into_iter().map(|val| val.stringify()).collect();
+            let strings: Result<Vec<String>> = v.iter().map(|val| val.stringify()).collect();
             match strings {
                 Ok(s) => Ok(Value::String(s.join(&sep))),
                 Err(_) => Err(interpreter_error!(
@@ -317,7 +317,7 @@ fn from_now_builtin(context: &Context, args: &[Value]) -> Result<Value> {
     };
 
     match v {
-        Value::String(s) => Ok(Value::String(from_now(&s, &reference)?)),
+        Value::String(s) => Ok(Value::String(from_now(s, &reference)?)),
         _ => Err(interpreter_error!(
             "BuiltinError: invalid arguments to builtin: fromNow"
         )),

--- a/rs/src/errors.rs
+++ b/rs/src/errors.rs
@@ -2,16 +2,6 @@
 
 use thiserror::Error;
 
-/// Construct a new syntax error, as an anyhow::Error
-macro_rules! syntax_error {
-    ($err:expr $(,)?) => ({
-        anyhow::Error::new($crate::errors::SyntaxError($err.to_string()))
-    });
-    ($fmt:expr, $($arg:tt)*) => {
-        anyhow::Error::new($crate::errors::SyntaxError(format!($fmt, $($arg)*)))
-    };
-}
-
 /// Construct a new interpreter error, as an anyhow::Error
 macro_rules! interpreter_error {
     ($err:expr $(,)?) => ({
@@ -30,27 +20,6 @@ macro_rules! template_error {
     ($fmt:expr, $($arg:tt)*) => {
         anyhow::Error::new($crate::errors::TemplateError(format!($fmt, $($arg)*)))
     };
-}
-
-/// Utility for asserting that an anyhow::Result contains a syntax error
-#[cfg(test)]
-macro_rules! assert_syntax_error {
-    ($left:expr, $right:expr) => ({
-        assert_eq!(
-            $left.expect_err("Expected an error, got").downcast_ref::<$crate::errors::SyntaxError>().expect("Expected a SyntaxError"),
-            &$crate::errors::SyntaxError($right.to_string())
-        );
-    });
-    ($left:expr, $right:expr,) => ({
-        assert_syntax_error!($left, $right)
-    });
-    ($left:expr, $right:expr, $($arg:tt)+) => ({
-        assert_eq!(
-            $left.expect_err("Expected an error, got").downcast_ref::<$crate::errors::SyntaxError>().expect("Expected a SyntaxError"),
-            &$crate::errors::SyntaxError($right.to_string()),
-            $($arg)*
-        );
-    });
 }
 
 /// Utility for asserting that an anyhow::Result contains an interpreter error
@@ -94,11 +63,6 @@ macro_rules! assert_template_error {
         );
     });
 }
-
-/// A SyntaxError indicates something wrong with the syntax of a JSON-e expression.
-#[derive(Debug, Error, Eq, PartialEq, Clone)]
-#[error("Syntax Error: {0}")]
-pub struct SyntaxError(pub(crate) String);
 
 /// An InterpreterError indicates something that failed during evaluation of a JSON-e expression.
 #[derive(Debug, Error, Eq, PartialEq, Clone)]

--- a/rs/src/fromnow.rs
+++ b/rs/src/fromnow.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::type_complexity)]
 use crate::whitespace::ws;
 use anyhow::{anyhow, Result};
 use chrono::{DateTime, Duration, Utc};
@@ -46,7 +47,7 @@ pub(crate) fn from_now(offset: &str, reference: &str) -> Result<String> {
 
 fn int(input: &str) -> IResult<&str, i64> {
     fn to_int(input: (&str, &str)) -> Result<i64, ()> {
-        Ok(input.0.parse().map_err(|_| ())?)
+        input.0.parse().map_err(|_| ())
     }
     map_res(tuple((digit1, multispace0)), to_int)(input)
 }

--- a/rs/src/interpreter/parser.rs
+++ b/rs/src/interpreter/parser.rs
@@ -22,7 +22,7 @@ use nom::{
 
 /// Parse a number token (integer or decimal)
 fn number(input: &str) -> IResult<&str, Node<'_>> {
-    fn node(input: &str) -> Result<Node, std::num::ParseIntError> {
+    fn node(input: &str) -> Result<Node<'_>, std::num::ParseIntError> {
         Ok(Node::Number(input))
     }
 
@@ -34,7 +34,7 @@ fn number(input: &str) -> IResult<&str, Node<'_>> {
 
 /// Parse a atomic literal JSON value (true, false, null)
 fn literal(input: &str) -> IResult<&str, Node<'_>> {
-    fn node(input: &str) -> Result<Node, ()> {
+    fn node(input: &str) -> Result<Node<'_>, ()> {
         Ok(match input {
             "true" => Node::True,
             "false" => Node::False,
@@ -64,7 +64,7 @@ fn ident_str(input: &str) -> IResult<&str, &str> {
 
 /// Parse an identifier as a Node
 fn ident(input: &str) -> IResult<&str, Node<'_>> {
-    fn node(input: &str) -> Result<Node, ()> {
+    fn node(input: &str) -> Result<Node<'_>, ()> {
         Ok(Node::Ident(input))
     }
 
@@ -87,7 +87,7 @@ fn string_str(input: &str) -> IResult<&str, &str> {
 
 /// Parse a string as a Node
 fn string(input: &str) -> IResult<&str, Node<'_>> {
-    fn node(input: &str) -> Result<Node, ()> {
+    fn node(input: &str) -> Result<Node<'_>, ()> {
         Ok(Node::String(input))
     }
 
@@ -311,7 +311,7 @@ fn expression(input: &str) -> IResult<&str, Node<'_>> {
 }
 
 /// Parse an entire string as an expression.  Un-parsed characters are treated as an error.
-pub(crate) fn parse_all(input: &str) -> anyhow::Result<Node> {
+pub(crate) fn parse_all(input: &str) -> anyhow::Result<Node<'_>> {
     match expression(input) {
         Ok(("", node)) => Ok(node),
         Ok((unused, _)) => Err(anyhow!("Unexpected trailing characters {}", unused)),
@@ -322,7 +322,7 @@ pub(crate) fn parse_all(input: &str) -> anyhow::Result<Node> {
 }
 
 /// Parse a part of a string as an expression, returning the remainder of the string.
-pub(crate) fn parse_partial(input: &str) -> anyhow::Result<(Node, &str)> {
+pub(crate) fn parse_partial(input: &str) -> anyhow::Result<(Node<'_>, &str)> {
     match expression(input) {
         Ok((unused, node)) => Ok((node, unused)),
         Err(Err::Incomplete(_)) => unreachable!(),

--- a/rs/src/value.rs
+++ b/rs/src/value.rs
@@ -69,52 +69,31 @@ impl Value {
     }
 
     pub(crate) fn is_null(&self) -> bool {
-        match self {
-            Value::Null => true,
-            _ => false,
-        }
+        matches!(self, Value::Null)
     }
 
     pub(crate) fn is_string(&self) -> bool {
-        match self {
-            Value::String(_) => true,
-            _ => false,
-        }
+        matches!(self, Value::String(_))
     }
 
     pub(crate) fn is_number(&self) -> bool {
-        match self {
-            Value::Number(_) => true,
-            _ => false,
-        }
+        matches!(self, Value::Number(_))
     }
 
     pub(crate) fn is_bool(&self) -> bool {
-        match self {
-            Value::Bool(_) => true,
-            _ => false,
-        }
+        matches!(self, Value::Bool(_))
     }
 
     pub(crate) fn is_object(&self) -> bool {
-        match self {
-            Value::Object(_) => true,
-            _ => false,
-        }
+        matches!(self, Value::Object(_))
     }
 
     pub(crate) fn is_array(&self) -> bool {
-        match self {
-            Value::Array(_) => true,
-            _ => false,
-        }
+        matches!(self, Value::Array(_))
     }
 
     pub(crate) fn is_deletion_marker(&self) -> bool {
-        match self {
-            Value::DeletionMarker => true,
-            _ => false,
-        }
+        matches!(self, Value::DeletionMarker)
     }
 
     /// A reference to the string, if this is a String variant
@@ -169,7 +148,7 @@ impl From<&Value> for bool {
             Value::Number(n) => *n != 0.0,
             Value::Bool(b) => *b,
             Value::Null => false,
-            Value::String(s) => s.len() > 0,
+            Value::String(s) => !s.is_empty(),
             Value::Array(a) => !a.is_empty(),
             Value::Object(o) => !o.is_empty(),
             Value::DeletionMarker => false,
@@ -223,7 +202,7 @@ impl TryFrom<&Value> for SerdeValue {
             ),
             Value::Array(a) => SerdeValue::Array(
                 a.iter()
-                    .map(|v| SerdeValue::try_from(v))
+                    .map(SerdeValue::try_from)
                     .collect::<Result<Vec<SerdeValue>>>()?,
             ),
             Value::DeletionMarker => SerdeValue::Null,
@@ -254,8 +233,8 @@ mod test {
         // These floats are chosen such that they exercise the assumption that
         // integer values outside (-u32::MAX..u32::MAX) are best represented as
         // floats.
-        let small_float = (-100_000_000_000_000 as i64) as f64;
-        let big_float = (100_000_000_000_000 as i64) as f64;
+        let small_float = -100_000_000_000_000f64;
+        let big_float = 100_000_000_000_000f64;
 
         let serde_value = json!({
             "the": "quick",


### PR DESCRIPTION
This is `cargo clippy --fix` plus applying a few things manually. Most of it is trivial, but surprisingly the SyntaxError type was unused, so has been removed.