### PR TITLE
Improve release process with pre-flight checks and Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.venv
+__pycache__
+js/node_modules
+rs/target
+py/dist
+py/build
+py/*.egg-info
+book

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,13 +63,13 @@ yarn rollup
 # Changelog
 
 When making a pull request with your changes, create a new file in
-`py/jsone/newsfragments/` named after the issue or bug you are working on, with
-a suffix of `.bugfix`, `.feature`, or (for docs-only changes) `.doc`.  The
-content of this file should be in reStructuredText format. Keep it to a simple
-sentence, and you should be fine!
+`newsfragments/` named after the issue or bug you are working on, with a suffix
+of `.bugfix`, `.feature`, or (for docs-only changes) `.doc`.  The content of
+this file should be in reStructuredText format. Keep it to a simple sentence,
+and you should be fine!
 
-For example, `py/jsone/newsfragments/201.bugfix` might contain `Fixed the
-precedence of the || and 'in' operators`.
+For example, `newsfragments/201.bugfix` might contain `Fixed the precedence of
+the || and 'in' operators`.
 
 Welcome to the team!
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,13 +63,14 @@ yarn rollup
 # Changelog
 
 When making a pull request with your changes, create a new file in
-`newsfragments/` named after the issue or bug you are working on, with a suffix
-of `.bugfix`, `.feature`, or (for docs-only changes) `.doc`.  The content of
-this file should be in reStructuredText format. Keep it to a simple sentence,
-and you should be fine!
+`py/jsone/newsfragments/` named after the issue or bug you are working on, with
+a suffix of `.bugfix`, `.feature`, or (for docs-only changes) `.doc`.  The
+content of this file should be in reStructuredText format. Keep it to a simple
+sentence, and you should be fine!
 
-For example, `newsfragments/201.bugfix` might contain `Fixed the precedence of
-the || and 'in' operators`.
+For example, `py/jsone/newsfragments/201.bugfix` might contain `Fixed the
+precedence of the || and 'in' operators`.
+
 Welcome to the team!
 
 [participation]: https://www.mozilla.org/en-US/about/governance/policies/participation/

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,0 +1,46 @@
+FROM debian:bookworm-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# System packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    ca-certificates \
+    curl \
+    git \
+    openssh-client \
+    pkg-config \
+    libssl-dev \
+    python3 \
+    python3-pip \
+    python3-venv \
+    && rm -rf /var/lib/apt/lists/*
+
+# Make python3 the default
+RUN ln -sf /usr/bin/python3 /usr/bin/python
+
+# Python release tools (installed globally with --break-system-packages
+# since this is a single-purpose container)
+RUN pip3 install --break-system-packages \
+    build \
+    twine \
+    towncrier
+
+# Node.js LTS (via NodeSource)
+RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# Enable corepack for yarn
+RUN corepack enable
+
+# Rust (via rustup)
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# mdbook (pre-built binary)
+RUN MDBOOK_VERSION="v0.4.40" && \
+    curl -fsSL "https://github.com/rust-lang/mdBook/releases/download/${MDBOOK_VERSION}/mdbook-${MDBOOK_VERSION}-x86_64-unknown-linux-gnu.tar.gz" \
+    | tar -xz -C /usr/local/bin
+
+WORKDIR /work

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -92,33 +92,9 @@ repository (it does not assume a specific remote name like `origin` or
 ssh -T git@github.com   # should show your username
 ```
 
-## Changelog (newsfragments)
-
-Every PR that changes user-facing behavior should include a newsfragment file.
-Create a file in `py/jsone/newsfragments/` named `<issue>.<type>` where `<type>`
-is one of:
-
-| Type | When to use |
-|------|-------------|
-| `.feature` | New functionality |
-| `.bugfix` | Bug fixes |
-| `.doc` | Documentation-only changes |
-
-The file content should be a single sentence in reStructuredText format
-describing the change. For example, `py/jsone/newsfragments/571.feature` might
-contain:
-
-```
-Improved release process with Docker support, pre-flight checks, and better diagnostics.
-```
-
-During a release, `towncrier build` compiles all newsfragment files into
-`CHANGELOG.rst` and deletes the individual fragment files. If there are no
-fragments, the changelog entry will be empty ("No significant changes").
-
 ## Registry permissions
 
-To publish, you must be a maintainer/owner on **all three** registries:
+To publish, you must be a maintainer/owner on all three registries:
 
 | Registry | How to check | How to grant |
 |----------|-------------|--------------|
@@ -131,26 +107,26 @@ on the specific package.
 
 ## What the release script does
 
-1. **Pre-flight checks** — verifies all tools, credentials, Python version,
+1. Pre-flight checks — verifies all tools, credentials, Python version,
    repo state (clean tree, on `main`, tag doesn't exist yet)
-2. **Changelog** — runs `towncrier build` to generate the changelog entry
-3. **Version bump** — updates version in `rs/Cargo.toml`, `js/package.json`,
+2. Changelog — runs `towncrier build` to generate the changelog entry
+3. Version bump — updates version in `rs/Cargo.toml`, `js/package.json`,
    and `py/setup.py`
-4. **Commit & tag** — creates a `v<version>` commit and tag
-5. **Publish** — uploads to crates.io, npm, and PyPI
-6. **Push** — pushes the commit and tag to GitHub
-7. **Docs** — rebuilds and deploys documentation via `deploy-docs.sh`
+4. Commit & tag — creates a `v<version>` commit and tag
+5. Publish — uploads to crates.io, npm, and PyPI
+6. Push — pushes the commit and tag to GitHub
+7. Docs — rebuilds and deploys documentation via `deploy-docs.sh`
 
 ## Partial failures
 
 The release script publishes to registries sequentially (crates.io, then npm,
 then PyPI). If a publish step fails partway through:
 
-- **The git commit and tag already exist locally** but may not have been pushed
+- The git commit and tag already exist locally but may not have been pushed
   yet (push happens last).
-- **Some registries may have the new version while others don't.** Most
+- Some registries may have the new version while others don't. Most
   registries don't support unpublishing (npm has a 72-hour window, crates.io
   does not allow it at all, PyPI does not allow re-uploading the same version).
-- **Fix forward**: resolve the issue and re-run the publish steps that failed,
+- Fix forward: resolve the issue and re-run the publish steps that failed,
   or cut a patch release if needed. The release script skips the changelog step
   if it detects the version already matches.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -92,6 +92,43 @@ repository (it does not assume a specific remote name like `origin` or
 ssh -T git@github.com   # should show your username
 ```
 
+## Changelog (newsfragments)
+
+Every PR that changes user-facing behavior should include a newsfragment file.
+Create a file in `py/jsone/newsfragments/` named `<issue>.<type>` where `<type>`
+is one of:
+
+| Type | When to use |
+|------|-------------|
+| `.feature` | New functionality |
+| `.bugfix` | Bug fixes |
+| `.doc` | Documentation-only changes |
+
+The file content should be a single sentence in reStructuredText format
+describing the change. For example, `py/jsone/newsfragments/571.feature` might
+contain:
+
+```
+Improved release process with Docker support, pre-flight checks, and better diagnostics.
+```
+
+During a release, `towncrier build` compiles all newsfragment files into
+`CHANGELOG.rst` and deletes the individual fragment files. If there are no
+fragments, the changelog entry will be empty ("No significant changes").
+
+## Registry permissions
+
+To publish, you must be a maintainer/owner on **all three** registries:
+
+| Registry | How to check | How to grant |
+|----------|-------------|--------------|
+| npm | `npm access ls-collaborators json-e` | `npm owner add <user> json-e` |
+| crates.io | Check [crates.io/crates/json-e](https://crates.io/crates/json-e) owners | `cargo owner --add <user> json-e` |
+| PyPI | Check [pypi.org/project/json-e](https://pypi.org/project/json-e/#files) maintainers | Add via PyPI project settings |
+
+Having valid credentials is not enough — your account must have publish rights
+on the specific package.
+
 ## What the release script does
 
 1. **Pre-flight checks** — verifies all tools, credentials, Python version,
@@ -103,3 +140,17 @@ ssh -T git@github.com   # should show your username
 5. **Publish** — uploads to crates.io, npm, and PyPI
 6. **Push** — pushes the commit and tag to GitHub
 7. **Docs** — rebuilds and deploys documentation via `deploy-docs.sh`
+
+## Partial failures
+
+The release script publishes to registries sequentially (crates.io, then npm,
+then PyPI). If a publish step fails partway through:
+
+- **The git commit and tag already exist locally** but may not have been pushed
+  yet (push happens last).
+- **Some registries may have the new version while others don't.** Most
+  registries don't support unpublishing (npm has a 72-hour window, crates.io
+  does not allow it at all, PyPI does not allow re-uploading the same version).
+- **Fix forward**: resolve the issue and re-run the publish steps that failed,
+  or cut a patch release if needed. The release script skips the changelog step
+  if it detects the version already matches.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,41 +1,105 @@
 # Making a Release
 
-Install:
- * Python: towncrier<20, setuptools, wheel and twine
- * Node / npm
- * Rust / cargo
- * mdbook (https://rust-lang.github.io/mdBook/guide/installation.html).
+There are two ways to run the release: inside Docker (recommended) or natively.
 
-Run
+## Option A: Docker-based release (recommended)
 
+This runs the release inside a container with all tools pre-installed. You only
+need Docker and credentials configured on the host.
+
+### Prerequisites
+
+1. **Docker** installed and running
+2. **Credentials** configured (see [Credential Setup](#credential-setup) below)
+3. **SSH agent** running with a key that has push access to `github.com:json-e/json-e`
+
+### Run
+
+```bash
+./release-docker.sh <version>   # without the `v` prefix
 ```
-./release.sh <version>  (without the `v` prefix)
+
+The script builds the Docker image (cached after first build), mounts your
+credentials read-only, forwards your SSH agent, and runs `release.sh` inside
+the container.
+
+## Option B: Native release
+
+Run the release directly on your machine.
+
+### Required tools
+
+| Tool | Install |
+|------|---------|
+| git | system package manager |
+| Python >= 3.10 | system package manager or pyenv |
+| pip packages: `build`, `twine`, `towncrier` | `pip install build twine towncrier` |
+| Node.js (LTS) + npm | https://nodejs.org or nvm |
+| yarn | `corepack enable` (ships with Node.js) |
+| Rust + cargo | https://rustup.rs |
+| mdbook | `cargo install mdbook` or [pre-built binary](https://github.com/rust-lang/mdBook/releases) |
+
+### Run
+
+```bash
+./release.sh <version>   # without the `v` prefix
 ```
 
-### Old Process:
+The script runs comprehensive pre-flight checks before doing any work. If
+anything is missing or misconfigured, it reports all failures at once so you can
+fix everything in one pass.
 
-* Run `towncrier --version=$newversion --draft` and check that the output looks OK.  Then run it without `--draft`, deleting the old newsfiles.  Commit.
-* Update the version in:
-  * `rs/Cargo.toml` and `rs/Cargo.lock`
-  * `js/package.json`
-  * `py/setup.py`
-* commit, and tag with `v$newversion`
-* Release to PyPi:
-  * `cd py/`
-  * (if you haven't already installed it..) `pip install wheel`
-  * `python setup.py sdist bdist_wheel`
-  * `twine upload dist/json-e-<version>.{tar.gz,whl}`
-* Release to npm:
-  * `npm publish` in `js/`
-* Release to crates.io:
-  * `cd rs/`
-  * `cp ../specification.yml .` - Cargo requires all necessary files to be in the directory, so temporarily include this file
-  * `cargo publish --allow-dirty`
-  * `rm specification.yml` - ..and remove the temporary file.  DO NOT CHECK IT IN!
-* Nothing to do for Go
-* Push -- `git push && git push --tags` (does this work?)
-* Documentation:
-  * Ensure you have `mdbook` installed (https://rust-lang.github.io/mdBook/guide/installation.html).
-  * Ensure you have a node environment set up.
-  * Ensure you have SSH access to push to the json-e/json-e repository.
-  * Run `./deploy.sh`
+## Credential Setup
+
+### npm (npmjs.com)
+
+```bash
+npm login
+```
+
+Verify with `npm whoami`.
+
+### crates.io (Rust)
+
+```bash
+cargo login
+```
+
+This saves a token to `~/.cargo/credentials.toml`. Alternatively, set the
+`CARGO_REGISTRY_TOKEN` environment variable.
+
+### PyPI
+
+Create a `~/.pypirc` file:
+
+```ini
+[pypi]
+username = __token__
+password = pypi-<your-api-token>
+```
+
+Or set `TWINE_USERNAME` and `TWINE_PASSWORD` environment variables. Generate an
+API token at https://pypi.org/manage/account/token/.
+
+### Git (SSH push access)
+
+Ensure you have an SSH key that can push to `github.com:json-e/json-e`. The
+release script auto-detects which git remote points to the `json-e/json-e`
+repository (it does not assume a specific remote name like `origin` or
+`upstream`).
+
+```bash
+ssh -T git@github.com   # should show your username
+```
+
+## What the release script does
+
+1. **Pre-flight checks** — verifies all tools, credentials, Python version,
+   repo state (clean tree, on `main`, tag doesn't exist yet)
+2. **Changelog** — runs `towncrier build` to generate the changelog entry
+3. **Version bump** — updates version in `rs/Cargo.toml`, `js/package.json`,
+   and `py/setup.py`
+4. **Commit & tag** — creates a `v<version>` commit and tag
+5. **Publish** — uploads to crates.io, npm, and PyPI
+6. **Push** — pushes the commit and tag to GitHub
+7. **Docs** — rebuilds and deploys documentation via `deploy-docs.sh`

--- a/py/jsone/newsfragments/571.feature
+++ b/py/jsone/newsfragments/571.feature
@@ -1,0 +1,1 @@
+Improved release process with Docker support, pre-flight checks, and better diagnostics.

--- a/release-docker.sh
+++ b/release-docker.sh
@@ -31,8 +31,11 @@ if [ -f "$HOME/.pypirc" ]; then
     MOUNTS+=(-v "$HOME/.pypirc:/root/.pypirc:ro")
 fi
 
-# SSH agent forwarding (use Docker's built-in support on macOS)
+# SSH: mount config, keys, known_hosts, and forward the agent
 SSH_ARGS=()
+if [ -d "$HOME/.ssh" ]; then
+    SSH_ARGS+=(-v "$HOME/.ssh:/root/.ssh:ro")
+fi
 if [ -n "${SSH_AUTH_SOCK:-}" ]; then
     if [[ "$(uname)" == "Darwin" ]]; then
         # macOS: Docker Desktop provides a magic path for SSH agent forwarding

--- a/release-docker.sh
+++ b/release-docker.sh
@@ -31,10 +31,15 @@ if [ -f "$HOME/.pypirc" ]; then
     MOUNTS+=(-v "$HOME/.pypirc:/root/.pypirc:ro")
 fi
 
-# SSH agent forwarding
+# SSH agent forwarding (use Docker's built-in support on macOS)
 SSH_ARGS=()
 if [ -n "${SSH_AUTH_SOCK:-}" ]; then
-    SSH_ARGS+=(-v "$SSH_AUTH_SOCK:/ssh-agent" -e "SSH_AUTH_SOCK=/ssh-agent")
+    if [[ "$(uname)" == "Darwin" ]]; then
+        # macOS: Docker Desktop provides a magic path for SSH agent forwarding
+        SSH_ARGS+=(-v /run/host-services/ssh-auth.sock:/ssh-agent -e "SSH_AUTH_SOCK=/ssh-agent")
+    else
+        SSH_ARGS+=(-v "$SSH_AUTH_SOCK:/ssh-agent" -e "SSH_AUTH_SOCK=/ssh-agent")
+    fi
 fi
 
 # Pass through PyPI env vars if set

--- a/release-docker.sh
+++ b/release-docker.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+set -e
+
+IMAGE_NAME="json-e-release"
+
+version="${1}"
+if [ -z "${version}" ] || [[ "${version}" == v* ]]; then
+    echo 'USAGE: ./release-docker.sh <version>  (without `v` prefix)'
+    exit 1
+fi
+
+# Build the release image if needed
+echo "=== Building release Docker image ==="
+docker build -f Dockerfile.release -t "$IMAGE_NAME" .
+
+# Collect credential mount arguments
+MOUNTS=()
+
+if [ -f "$HOME/.cargo/credentials.toml" ]; then
+    MOUNTS+=(-v "$HOME/.cargo/credentials.toml:/root/.cargo/credentials.toml:ro")
+elif [ -f "$HOME/.cargo/credentials" ]; then
+    MOUNTS+=(-v "$HOME/.cargo/credentials:/root/.cargo/credentials:ro")
+fi
+
+if [ -f "$HOME/.npmrc" ]; then
+    MOUNTS+=(-v "$HOME/.npmrc:/root/.npmrc:ro")
+fi
+
+if [ -f "$HOME/.pypirc" ]; then
+    MOUNTS+=(-v "$HOME/.pypirc:/root/.pypirc:ro")
+fi
+
+# SSH agent forwarding
+SSH_ARGS=()
+if [ -n "${SSH_AUTH_SOCK:-}" ]; then
+    SSH_ARGS+=(-v "$SSH_AUTH_SOCK:/ssh-agent" -e "SSH_AUTH_SOCK=/ssh-agent")
+fi
+
+# Pass through PyPI env vars if set
+ENV_ARGS=()
+if [ -n "${TWINE_USERNAME:-}" ]; then
+    ENV_ARGS+=(-e "TWINE_USERNAME=$TWINE_USERNAME")
+fi
+if [ -n "${TWINE_PASSWORD:-}" ]; then
+    ENV_ARGS+=(-e "TWINE_PASSWORD=$TWINE_PASSWORD")
+fi
+if [ -n "${CARGO_REGISTRY_TOKEN:-}" ]; then
+    ENV_ARGS+=(-e "CARGO_REGISTRY_TOKEN=$CARGO_REGISTRY_TOKEN")
+fi
+if [ -n "${NPM_TOKEN:-}" ]; then
+    ENV_ARGS+=(-e "NPM_TOKEN=$NPM_TOKEN")
+fi
+
+echo "=== Running release inside Docker ==="
+docker run --rm -it \
+    -v "$(pwd):/work" \
+    "${MOUNTS[@]}" \
+    "${SSH_ARGS[@]}" \
+    "${ENV_ARGS[@]}" \
+    "$IMAGE_NAME" \
+    ./release.sh "$version"

--- a/release.sh
+++ b/release.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/bin/bash
 
 set -e
 
@@ -8,45 +8,170 @@ if [ -z "${version}" ] || [[ "${version}" == v* ]]; then
     exit 1
 fi
 
-check_binaries() {
-    for bin in git towncrier twine python npm cargo mdbook; do
-        if ! which ${bin} >/dev/null; then
-            echo "Install ${bin} first."
-            exit 1
-        fi
-    done
-}
-
-check_tag() {
-    if git rev-parse "v${version}" 2>/dev/null >/dev/null; then
-        echo "Version ${version} is already tagged."
-        exit 1
+######################################################################
+# Portable sed -i (macOS sed treats -i -e differently from GNU sed)
+######################################################################
+portable_sed() {
+    if [[ "$OSTYPE" == darwin* ]]; then
+        sed -i '' "$@"
+    else
+        sed -i "$@"
     fi
 }
 
+######################################################################
+# Detect which git remote points to json-e/json-e
+######################################################################
+detect_remote() {
+    local remote
+    for remote in $(git remote); do
+        local url
+        url=$(git remote get-url "$remote" 2>/dev/null || true)
+        if [[ "$url" == *"github.com"*"json-e/json-e"* ]]; then
+            echo "$remote"
+            return
+        fi
+    done
+    return 1
+}
+
+######################################################################
+# Pre-flight checks — run ALL checks, report ALL failures at once
+######################################################################
+preflight() {
+    local errors=()
+
+    echo "=== Pre-flight checks ==="
+
+    # Required binaries
+    for bin in git towncrier twine python npm cargo mdbook yarn; do
+        if ! command -v "$bin" >/dev/null 2>&1; then
+            errors+=("Missing binary: $bin")
+        fi
+    done
+
+    # Python version >= 3.10
+    if command -v python >/dev/null 2>&1; then
+        local pyver
+        pyver=$(python -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
+        local pymajor=${pyver%%.*}
+        local pyminor=${pyver##*.}
+        if [ "$pymajor" -lt 3 ] || { [ "$pymajor" -eq 3 ] && [ "$pyminor" -lt 10 ]; }; then
+            errors+=("Python >= 3.10 required (found $pyver)")
+        fi
+    fi
+
+    # Python packages
+    if command -v python >/dev/null 2>&1; then
+        if ! python -m build --help >/dev/null 2>&1; then
+            errors+=("Python 'build' package not installed (pip install build)")
+        fi
+    fi
+    if command -v towncrier >/dev/null 2>&1; then
+        if ! towncrier --version >/dev/null 2>&1; then
+            errors+=("towncrier not working")
+        fi
+    fi
+    if command -v twine >/dev/null 2>&1; then
+        if ! twine --version >/dev/null 2>&1; then
+            errors+=("twine not working")
+        fi
+    fi
+
+    # npm auth
+    if command -v npm >/dev/null 2>&1; then
+        if ! npm whoami >/dev/null 2>&1; then
+            errors+=("npm not authenticated (run: npm login)")
+        fi
+    fi
+
+    # cargo / crates.io auth
+    if command -v cargo >/dev/null 2>&1; then
+        if [ ! -f "$HOME/.cargo/credentials.toml" ] && \
+           [ ! -f "$HOME/.cargo/credentials" ] && \
+           [ -z "${CARGO_REGISTRY_TOKEN:-}" ]; then
+            errors+=("crates.io not authenticated (run: cargo login)")
+        fi
+    fi
+
+    # PyPI auth
+    if [ ! -f "$HOME/.pypirc" ] && \
+       [ -z "${TWINE_USERNAME:-}" ] && \
+       [ -z "${TWINE_PASSWORD:-}" ]; then
+        errors+=("PyPI not authenticated (create ~/.pypirc or set TWINE_USERNAME/TWINE_PASSWORD)")
+    fi
+
+    # Git remote
+    REMOTE=$(detect_remote) || true
+    if [ -z "${REMOTE:-}" ]; then
+        errors+=("No git remote pointing to github.com:json-e/json-e found")
+    else
+        echo "  Using git remote: $REMOTE"
+        if ! git ls-remote "$REMOTE" >/dev/null 2>&1; then
+            errors+=("Git remote '$REMOTE' is not reachable (check SSH keys / network)")
+        fi
+    fi
+
+    # Repo state: clean working tree
+    if [ -n "$(git status --porcelain)" ]; then
+        errors+=("Working tree is not clean (commit or stash changes first)")
+    fi
+
+    # Repo state: on main branch
+    local branch
+    branch=$(git rev-parse --abbrev-ref HEAD)
+    if [ "$branch" != "main" ]; then
+        errors+=("Not on main branch (currently on '$branch')")
+    fi
+
+    # Tag doesn't already exist
+    if git rev-parse "v${version}" >/dev/null 2>&1; then
+        errors+=("Tag v${version} already exists")
+    fi
+
+    # Report
+    if [ ${#errors[@]} -gt 0 ]; then
+        echo ""
+        echo "Pre-flight FAILED with ${#errors[@]} error(s):"
+        for err in "${errors[@]}"; do
+            echo "  - $err"
+        done
+        echo ""
+        exit 1
+    fi
+
+    echo "  All pre-flight checks passed."
+    echo ""
+}
+
+######################################################################
+# Release steps
+######################################################################
+
 update_changelog() {
-    local cl_version=$(head -n 1 CHANGELOG.rst | cut -d' ' -f 2)
+    local cl_version
+    cl_version=$(head -n 1 CHANGELOG.rst | cut -d' ' -f 2)
     if [ "${cl_version}" == "${version}" ]; then
         return
     fi
-    towncrier build --version=$version --draft
+    towncrier build --version="$version" --draft
     read -p "Look OK? (ctrl-c if not, enter if OK)"
-    towncrier build --version=$version --yes
+    towncrier build --version="$version" --yes
 }
 
 update_version_rs() {
-    sed -i -e "s/^version = \"[0-9.]*\"/version = \"$version\"/" rs/Cargo.toml
-    ( cd rs; cargo build )
-    git add rs/Cargo.{toml,lock}
+    portable_sed "s/^version = \"[0-9.]*\"/version = \"$version\"/" rs/Cargo.toml
+    ( cd rs && cargo build )
+    git add rs/Cargo.toml rs/Cargo.lock
 }
 
 update_version_js() {
-    sed -i -e "s/\"version\": \"[0-9.]*\"/\"version\": \"$version\"/" js/package.json
+    portable_sed "s/\"version\": \"[0-9.]*\"/\"version\": \"$version\"/" js/package.json
     git add js/package.json
 }
 
 update_version_py() {
-    sed -i -e "s/^version = \"[0-9.]*\"/version = \"$version\"/" py/setup.py
+    portable_sed "s/^version = \"[0-9.]*\"/version = \"$version\"/" py/setup.py
     git add py/setup.py
 }
 
@@ -65,7 +190,7 @@ upload_rs() {
 
 upload_js() {
     cd js
-    npm install
+    yarn install
     npm publish
     cd ..
 }
@@ -73,19 +198,21 @@ upload_js() {
 upload_py() {
     cd py
     rm -rf dist/*
-    python setup.py sdist bdist_wheel
+    python -m build
     twine upload dist/*
     cd ..
 }
 
 push_git() {
-    git push upstream main:main
-    git push upstream --follow-tags "v$version"
+    git push "$REMOTE" main:main
+    git push "$REMOTE" --follow-tags "v$version"
 }
 
-# Check stuff
-check_tag
-check_binaries
+######################################################################
+# Main
+######################################################################
+
+preflight
 
 # Update the repo contents and commit
 update_changelog

--- a/release.sh
+++ b/release.sh
@@ -80,24 +80,40 @@ preflight() {
 
     # npm auth
     if command -v npm >/dev/null 2>&1; then
-        if ! npm whoami >/dev/null 2>&1; then
+        local npm_user
+        npm_user=$(npm whoami 2>/dev/null) || true
+        if [ -n "$npm_user" ]; then
+            echo "  npm: authenticated as $npm_user"
+        else
             errors+=("npm not authenticated (run: npm login)")
         fi
     fi
 
     # cargo / crates.io auth
     if command -v cargo >/dev/null 2>&1; then
-        if [ ! -f "$HOME/.cargo/credentials.toml" ] && \
-           [ ! -f "$HOME/.cargo/credentials" ] && \
-           [ -z "${CARGO_REGISTRY_TOKEN:-}" ]; then
+        if [ -n "${CARGO_REGISTRY_TOKEN:-}" ]; then
+            echo "  crates.io: authenticated via CARGO_REGISTRY_TOKEN env var"
+        elif [ -f "$HOME/.cargo/credentials.toml" ]; then
+            echo "  crates.io: authenticated via ~/.cargo/credentials.toml"
+        elif [ -f "$HOME/.cargo/credentials" ]; then
+            echo "  crates.io: authenticated via ~/.cargo/credentials"
+        else
             errors+=("crates.io not authenticated (run: cargo login)")
         fi
     fi
 
     # PyPI auth
-    if [ ! -f "$HOME/.pypirc" ] && \
-       [ -z "${TWINE_USERNAME:-}" ] && \
-       [ -z "${TWINE_PASSWORD:-}" ]; then
+    if [ -n "${TWINE_USERNAME:-}" ]; then
+        echo "  PyPI: authenticated as $TWINE_USERNAME (via env var)"
+    elif [ -f "$HOME/.pypirc" ]; then
+        local pypi_user
+        pypi_user=$(grep -A5 '\[pypi\]' "$HOME/.pypirc" 2>/dev/null | grep 'username' | head -1 | sed 's/.*=\s*//' || true)
+        if [ -n "$pypi_user" ]; then
+            echo "  PyPI: authenticated as $pypi_user (via ~/.pypirc)"
+        else
+            echo "  PyPI: authenticated via ~/.pypirc"
+        fi
+    else
         errors+=("PyPI not authenticated (create ~/.pypirc or set TWINE_USERNAME/TWINE_PASSWORD)")
     fi
 
@@ -112,16 +128,16 @@ preflight() {
         fi
     fi
 
-    # Repo state: clean working tree
-    if [ -n "$(git status --porcelain)" ]; then
-        errors+=("Working tree is not clean (commit or stash changes first)")
-    fi
-
     # Repo state: on main branch
     local branch
     branch=$(git rev-parse --abbrev-ref HEAD)
     if [ "$branch" != "main" ]; then
-        errors+=("Not on main branch (currently on '$branch')")
+        errors+=("Not on main branch (currently on '$branch'). To fix: git checkout main")
+    fi
+
+    # Repo state: clean working tree
+    if [ -n "$(git status --porcelain)" ]; then
+        errors+=("Working tree is not clean — see details below")
     fi
 
     # Tag doesn't already exist
@@ -136,6 +152,24 @@ preflight() {
         for err in "${errors[@]}"; do
             echo "  - $err"
         done
+
+        # Show working tree details if dirty
+        if [ -n "$(git status --porcelain)" ]; then
+            echo ""
+            echo "Working tree status:"
+            git status --short
+            echo ""
+            echo "To inspect changes before discarding:"
+            echo "  git diff                   # staged and unstaged changes to tracked files"
+            echo "  git diff --cached          # staged changes only"
+            echo "  git status                 # full status including untracked files"
+            echo ""
+            echo "To discard ALL local changes (WARNING: this is irreversible):"
+            echo "  git checkout main          # switch to main branch"
+            echo "  git reset --hard HEAD      # discard all changes to tracked files"
+            echo "  git clean -fd              # delete untracked files and directories"
+        fi
+
         echo ""
         exit 1
     fi


### PR DESCRIPTION
## Summary

- Add comprehensive pre-flight checks to `release.sh` that verify **all** prerequisites (binaries, Python version, auth for npm/crates.io/PyPI, git remote reachability, clean working tree) and report **all** failures at once instead of failing one-by-one mid-release
- Fix `sed -i` portability on macOS by using a `portable_sed()` helper (no more `*-e` backup files)
- Replace `python setup.py sdist bdist_wheel` with `python -m build` to avoid the `pkg_resources` breakage from setuptools 82+
- Auto-detect the git remote pointing to `json-e/json-e` instead of hardcoding `upstream`
- Add `Dockerfile.release` and `release-docker.sh` for a consistent, reproducible release environment
- Rewrite `RELEASING.md` with Docker-based (recommended) and native release instructions, plus credential setup docs

## Motivation

The 4.8.2 release required multiple repo re-clones due to mid-release failures from missing tools, broken auth, sed portability issues, and pkg_resources removal. These changes ensure the script catches all problems before making any changes.

## Test plan

- [x] `./release.sh` with no args shows usage and exits 1
- [x] `./release.sh 99.99.99` on a clean checkout reports all missing auth/tools clearly
- [x] Verify no `*-e` backup files created by sed on macOS
- [x] `docker build -f Dockerfile.release -t json-e-release .` builds successfully
- [x] Verify Docker image has all required tools: node, yarn, python, cargo, mdbook, towncrier, twine

🤖 Generated with [Claude Code](https://claude.com/claude-code)