### PR TITLE
Add CLAUDE.md and expand CONTRIBUTING.md with project details

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ env
 rs/target
 rs/**/*.rs.bk
 book
+
+# Claude Code local session data
+.claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+See CONTRIBUTING.md for project overview, build commands, architecture, and contribution conventions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,21 +1,13 @@
-# General Taskcluster Contribution
+# Contributing to JSON-e
 
 We welcome pull requests from everyone. We do expect everyone to adhere to the [Mozilla Community Participation Guidelines][participation].
 
-If you're trying to figure out what to work on, here are some places to find suitable projects: 
-* [Good first bugs][goodfirstbug]: these are scoped to make it easy for first-time contributors to get their feet wet with Taskcluster code.
-* [Mentored bugs][bugsahoy]: these are slightly more involved projects that may require insight or guidance from someone on the Taskcluster team.
-* [Full list of open issues][issues]: everything else
+If you're trying to figure out what to work on, have a look at the [open issues][issues].
+If you're unsure about how to proceed on an existing issue, feel free to add a comment to it.
 
-If the project you're interested in working on isn't covered by a bug or issue, or you're unsure about how to proceed on an existing issue, it's a good idea to talk to someone on the Taskcluster team before you go too far down a particular path. You can find us in the #taskcluster channel on [Mozilla's IRC server][irc] to discuss. You can also simply add a comment to the issue or bug.
-
-Once you've found an issue to work on and written a patch, submit a pull request. Some things that will increase the chance that your pull request is accepted:
-
-* Follow our [best practices][bestpractices].
-* This includes [writing or updating tests][testing].
-* Write a [good commit message][commit].
-
-# JSON-e Contribution
+JSON-e is a data-structure parameterization system for embedding context in
+JSON objects. It operates on data structures directly (not strings), ensuring
+output validity and safety (no eval, no unbounded iteration).
 
 JSON-e is implemented in several languages. All implementations should behave
 identically, and the test suite subjects each implementation to the same
@@ -29,6 +21,13 @@ The JavaScript implementation is located in `./js`
 Within that directory, run `yarn install` to install the required packages for JSON-e's execution and development.
 To run the tests use `yarn test`
 
+There are also a few other useful commands:
+
+```bash
+cd js && yarn lint             # eslint only
+cd js && yarn rollup           # bundle for browser (UMD)
+```
+
 ## Python
 
 The Python implementation is located in `./py`.
@@ -37,15 +36,59 @@ To test this implementation, install and run `tox` within that directory.
 This will test on all supported Python versions.
 If you have fewer Python versions installed, that's OK -- when you make a PR it will run for all versions.
 
+You can also run tests more selectively:
+
+```bash
+cd py && tox -e py311          # run tests on a single Python version
+cd py && tox -e lint           # run black formatter check
+cd py && pytest                # run tests directly (requires deps installed)
+```
+
 ## Go
 
 The Go implementation is located in `internal/`, with a small stub in `jsone.go` in the root directory.
 This follows the usual GoModules form, so running `go test ./...` in the root dir will run the tests.
 
+For linting, use `golangci-lint run`.
+
 ## Rust
 
 The Rust implementation is in `rs/`.
 Within that directory, you will find a `Cargo.toml` and the usual Rust development tools apply: `cargo test`, `cargo build`, and so on.
+You can also run `cargo clippy` for linting.
+
+## Architecture
+
+Each implementation follows the same general architecture:
+
+1. A **tokenizer** breaks expression strings into tokens
+2. A **Pratt parser** produces an AST
+3. An **interpreter** evaluates AST nodes in a context
+4. A **renderer** walks JSON templates, recognizes `$`-operators (`$if`, `$eval`, `$map`, etc.), and recursively renders
+5. **Builtins** provide functions available in expressions (`min`, `max`, `len`, `lowercase`, `fromNow`, etc.)
+
+`specification.yml` in the repo root is the single source of truth. It defines
+the JSON-e language through hundreds of test cases (template + context →
+expected result or error). All four implementations load and run these same
+tests, ensuring behavioral consistency — any discrepancy is a bug.
+
+Here's where the key components live in each implementation:
+
+| Component | JS | Python | Go | Rust |
+|---|---|---|---|---|
+| Entry/Renderer | `js/src/index.js` | `py/jsone/render.py` | `internal/jsone.go` | `rs/src/render.rs` |
+| Parser | `js/src/parser.js` | `py/jsone/parser.py` | `internal/interpreter/parser/parser.go` | `rs/src/interpreter/parser.rs` |
+| Interpreter | `js/src/interpreter.js` | `py/jsone/interpreter.py` | `internal/interpreter/interpreter.go` | `rs/src/interpreter/evaluator.rs` |
+| Builtins | `js/src/builtins.js` | `py/jsone/builtins.py` | `internal/jsone.go` (inline) | `rs/src/builtins.rs` |
+
+The Go public API in `jsone.go` (root) is a thin wrapper around `internal/`.
+
+The spec tests are loaded slightly differently in each language:
+
+- **JS**: `js/test/specification_test.js` parses the YAML and creates mocha suites
+- **Python**: `py/test/test_specification.py` uses pytest parametrize from the YAML
+- **Go**: `internal/jsone_test.go` loads the YAML and runs subtests
+- **Rust**: `rs/build.rs` generates test source at compile time from the YAML
 
 # Documentation
 
@@ -70,14 +113,10 @@ and you should be fine!
 
 For example, `newsfragments/201.bugfix` might contain `Fixed the precedence of
 the || and 'in' operators`.
+
+Note that test time is frozen to `2017-01-19T16:27:20.974Z` across all implementations.
+
 Welcome to the team!
 
 [participation]: https://www.mozilla.org/en-US/about/governance/policies/participation/
 [issues]: ../../issues
-[bugsahoy]: https://www.joshmatthews.net/bugsahoy/?taskcluster=1
-[goodfirstbug]: http://www.joshmatthews.net/bugsahoy/?taskcluster=1&simple=1
-[irc]: https://wiki.mozilla.org/IRC
-[bestpractices]: https://docs.taskcluster.net/docs/manual/design/devel/best-practices
-[testing]: https://docs.taskcluster.net/docs/manual/design/devel/best-practices/testing
-[commit]: https://docs.taskcluster.net/docs/manual/design/devel/best-practices/commits
-


### PR DESCRIPTION
## Summary

- Move project overview, build/test commands, architecture details, and contribution conventions from `CLAUDE.md` into `CONTRIBUTING.md`, as suggested in review
- Preserve the original conversational style of `CONTRIBUTING.md` and weave in the new information alongside existing sections rather than replacing them
- Replace the Taskcluster-specific intro (bugsahoy, IRC, etc.) with a simpler welcome — json-e is no longer part of Taskcluster
- Add a minimal `CLAUDE.md` that points to `CONTRIBUTING.md`
- Gitignore `.claude/` (Claude Code local session data)

## Test plan

- [ ] Verify `CONTRIBUTING.md` reads well as a single coherent document
- [ ] Verify `CLAUDE.md` correctly points to `CONTRIBUTING.md`
- [ ] No functional code changes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)