### PR TITLE
Add release preflight checks for upstream sync, remote tags, and published packages

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -108,7 +108,9 @@ on the specific package.
 ## What the release script does
 
 1. Pre-flight checks — verifies all tools, credentials, Python version,
-   repo state (clean tree, on `main`, tag doesn't exist yet)
+   repo state (clean tree, on `main`, in sync with upstream), tag doesn't
+   exist (locally or on remote), and version not already published to any
+   registry
 2. Changelog — runs `towncrier build` to generate the changelog entry
 3. Version bump — updates version in `rs/Cargo.toml`, `js/package.json`,
    and `py/setup.py`
@@ -122,11 +124,16 @@ on the specific package.
 The release script publishes to registries sequentially (crates.io, then npm,
 then PyPI). If a publish step fails partway through:
 
-- The git commit and tag already exist locally but may not have been pushed
-  yet (push happens last).
-- Some registries may have the new version while others don't. Most
-  registries don't support unpublishing (npm has a 72-hour window, crates.io
-  does not allow it at all, PyPI does not allow re-uploading the same version).
-- Fix forward: resolve the issue and re-run the publish steps that failed,
-  or cut a patch release if needed. The release script skips the changelog step
-  if it detects the version already matches.
+- The git commit and tag exist locally but may not have been pushed yet (push
+  happens after all registry uploads).
+- Some registries may have the new version while others don't. None of the
+  registries allow re-publishing the same version number (npm allows
+  unpublishing within 72 hours, but crates.io and PyPI do not).
+
+To recover from a partial failure:
+
+1. Consider adding a pre-flight check to `release.sh` so the same failure
+   mode cannot recur in future releases.
+2. Increment the patch version (json-e uses semver) and release again. The
+   pre-flight checks will detect and report which registries already have the
+   failed version, so you can confirm the state before proceeding.

--- a/py/jsone/newsfragments/577.feature
+++ b/py/jsone/newsfragments/577.feature
@@ -1,0 +1,1 @@
+Release script now checks that the local main branch is in sync with upstream, that the release tag does not already exist on the remote, and that the version has not already been published to npm, PyPI, or crates.io.

--- a/release.sh
+++ b/release.sh
@@ -140,9 +140,39 @@ preflight() {
         errors+=("Working tree is not clean — see details below")
     fi
 
-    # Tag doesn't already exist
+    # Repo state: local main must match upstream main
+    if [ -n "${REMOTE:-}" ] && [ "$branch" == "main" ]; then
+        local local_head remote_head
+        local_head=$(git rev-parse HEAD)
+        remote_head=$(git ls-remote "$REMOTE" refs/heads/main 2>/dev/null | cut -f1)
+        if [ -n "$remote_head" ] && [ "$local_head" != "$remote_head" ]; then
+            errors+=("Local main ($local_head) differs from $REMOTE/main ($remote_head). Run: git pull --ff-only $REMOTE main")
+        fi
+    fi
+
+    # Tag doesn't already exist (locally or on remote)
     if git rev-parse "v${version}" >/dev/null 2>&1; then
-        errors+=("Tag v${version} already exists")
+        errors+=("Tag v${version} already exists locally")
+    fi
+    if [ -n "${REMOTE:-}" ]; then
+        local remote_tag
+        remote_tag=$(git ls-remote --tags "$REMOTE" "refs/tags/v${version}" 2>/dev/null | cut -f1)
+        if [ -n "$remote_tag" ]; then
+            errors+=("Tag v${version} already exists on remote '$REMOTE'")
+        fi
+    fi
+
+    # Package not already published to registries
+    if command -v curl >/dev/null 2>&1; then
+        if curl -sf "https://registry.npmjs.org/json-e/${version}" >/dev/null 2>&1; then
+            errors+=("Version ${version} already published on npm")
+        fi
+        if curl -sf "https://pypi.org/pypi/json-e/${version}/json" >/dev/null 2>&1; then
+            errors+=("Version ${version} already published on PyPI")
+        fi
+        if curl -sf "https://crates.io/api/v1/crates/json-e/${version}" >/dev/null 2>&1; then
+            errors+=("Version ${version} already published on crates.io")
+        fi
     fi
 
     # Report


### PR DESCRIPTION
## Summary

- Verify local `main` HEAD matches the upstream remote's `main` before releasing, catching ahead/behind/diverged states that would cause `git push` to fail mid-release (after packages are already published)
- Check the release tag on the remote (via `git ls-remote --tags`), not just locally, preventing conflicts when `git push --follow-tags` runs
- Query npm, PyPI, and crates.io registries to verify the version hasn't already been published, catching partial release recovery scenarios where git tags were cleaned up but packages remain on registries
- Update RELEASING.md partial-failure guidance to recommend bumping the patch version rather than trying to re-run failed steps

Fixes #577, fixes #578, fixes #580.

## Test plan

These checks require running `./release.sh` on `main` with release tooling installed. Registry URL checks were verified independently via `curl`:

- [ ] Run `./release.sh 99.99.99` on a checkout that is behind upstream — should report the mismatch with both commit hashes
- [ ] Create a local tag `v99.99.99`, run `./release.sh 99.99.99` — should report "already exists locally"
- [ ] Delete local tag, verify the existing `v4.8.2` tag is caught as existing on remote: `./release.sh 4.8.2`
- [x] `curl -sf https://registry.npmjs.org/json-e/4.8.2` returns success for existing version, failure for 99.99.99
- [x] `curl -sf https://pypi.org/pypi/json-e/4.8.2/json` returns success for existing version, failure for 99.99.99
- [x] `curl -sf https://crates.io/api/v1/crates/json-e/4.8.2` returns success for existing version, failure for 99.99.99
- [ ] Verify all errors appear together (not one-at-a-time) when multiple conditions fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)