### PR TITLE
fix: enforce spec error messages in the Go implementation

### DIFF
--- a/internal/interpreter/execute.go
+++ b/internal/interpreter/execute.go
@@ -18,6 +18,10 @@ var tokenizer = *p.NewTokenizer(`\s+`, strings.Split(
 	"null":       `null\b`,
 })
 
+var expectedInfixTokens = strings.Split(
+	`!= && ( * ** + - . / < <= == > >= [ in ||`, " ",
+)
+
 func Parse(source string, context interface{}) (interface{}, error) {
 	var parser p.Parser
 	var newInterpreter NewInterpreter
@@ -31,10 +35,10 @@ func Parse(source string, context interface{}) (interface{}, error) {
 	}
 	if !parser.CurrentToken.IsEmpty() {
 		return nil, p.SyntaxError{
-			Message: "expected end of input",
-			Source:  source,
-			Start:   parser.CurrentToken.Start,
-			End:     parser.CurrentToken.End,
+			Source:   source,
+			Start:    parser.CurrentToken.Start,
+			End:      parser.CurrentToken.End,
+			Expected: expectedInfixTokens,
 		}
 	}
 	newInterpreter.AddContext(context.(map[string]interface{}))
@@ -54,12 +58,17 @@ func ParseUntilTerminator(source string, offset int, terminator string, context 
 	if err != nil {
 		return nil, 0, err
 	}
+	if parser.CurrentToken.IsEmpty() {
+		return nil, 0, p.SyntaxError{
+			Message: "unterminated ${..} expression",
+		}
+	}
 	if parser.CurrentToken.Kind != terminator {
 		return nil, 0, p.SyntaxError{
 			Source:   source,
 			Start:    parser.CurrentToken.Start,
 			End:      parser.CurrentToken.End,
-			Expected: []string{terminator},
+			Expected: expectedInfixTokens,
 		}
 	}
 	newInterpreter.AddContext(context.(map[string]interface{}))

--- a/internal/interpreter/interpreter.go
+++ b/internal/interpreter/interpreter.go
@@ -15,6 +15,46 @@ type NewInterpreter struct {
 	context map[string]interface{}
 }
 
+// InterpreterError indicates an error while evaluating an expression.
+type InterpreterError struct {
+	Message  string
+	Location []string
+}
+
+func (e InterpreterError) Error() string {
+	location := ""
+	if len(e.Location) > 0 {
+		location = " at template" + strings.Join(e.Location, "")
+	}
+	return fmt.Sprintf("InterpreterError%s: %s", location, e.Message)
+}
+
+// AddLocation returns a copy of the error with a location prepended.
+func (e InterpreterError) AddLocation(location string) error {
+	e.Location = append([]string{location}, e.Location...)
+	return e
+}
+
+// BuiltinError indicates invalid arguments to a builtin function.
+type BuiltinError struct {
+	Message  string
+	Location []string
+}
+
+func (e BuiltinError) Error() string {
+	location := ""
+	if len(e.Location) > 0 {
+		location = " at template" + strings.Join(e.Location, "")
+	}
+	return fmt.Sprintf("BuiltinError%s: %s", location, e.Message)
+}
+
+// AddLocation returns a copy of the error with a location prepended.
+func (e BuiltinError) AddLocation(location string) error {
+	e.Location = append([]string{location}, e.Location...)
+	return e
+}
+
 func (i *NewInterpreter) AddContext(context map[string]interface{}) {
 	i.context = context
 }
@@ -66,15 +106,15 @@ func (i NewInterpreter) Visit_UnaryOp(node parser.UnaryOp) (interface{}, error) 
 	switch node.Token.Kind {
 	case "+":
 		if !isNumber(value) {
-			return nil, parser.SyntaxError{
-				Message: "Expected number after +",
+			return nil, InterpreterError{
+				Message: "unary + expects number",
 			}
 		}
 		return +value.(float64), nil
 	case "-":
 		if !isNumber(value) {
-			return nil, parser.SyntaxError{
-				Message: "Expected number after -",
+			return nil, InterpreterError{
+				Message: "unary - expects number",
 			}
 		}
 		return -value.(float64), nil
@@ -132,18 +172,18 @@ func (i NewInterpreter) Visit_BinOp(node parser.BinOp) (interface{}, error) {
 			if value, ok := target[key]; ok {
 				return value, nil
 			}
-			return nil, parser.SyntaxError{
-				Message: "object has no such property",
+			return nil, InterpreterError{
+				Message: fmt.Sprintf("object has no property %q", key),
 			}
 		}
-		return nil, parser.SyntaxError{
-			Message: "cannot access properties of non-object",
+		return nil, InterpreterError{
+			Message: "infix: . expects objects",
 		}
 	case "in":
 		// A in B, where B is a string
 		if s, ok := right.(string); ok {
 			if !isString(left) {
-				return nil, parser.SyntaxError{
+				return nil, InterpreterError{
 					Message: "in operator expected a string when querying on a string",
 				}
 			}
@@ -153,7 +193,7 @@ func (i NewInterpreter) Visit_BinOp(node parser.BinOp) (interface{}, error) {
 		// A in B; where B is an object
 		if o, ok := right.(map[string]interface{}); ok {
 			if !isString(left) {
-				return nil, parser.SyntaxError{
+				return nil, InterpreterError{
 					Message: "in operator expected a string when querying on an object",
 				}
 			}
@@ -171,7 +211,7 @@ func (i NewInterpreter) Visit_BinOp(node parser.BinOp) (interface{}, error) {
 			return false, nil
 		}
 
-		return nil, parser.SyntaxError{
+		return nil, InterpreterError{
 			Message: "in operator expected string, array or object",
 		}
 	case "+":
@@ -181,8 +221,8 @@ func (i NewInterpreter) Visit_BinOp(node parser.BinOp) (interface{}, error) {
 		if isString(left) && isString(right) {
 			return left.(string) + right.(string), nil
 		}
-		return nil, parser.SyntaxError{
-			Message: "Expected either number of string operands",
+		return nil, InterpreterError{
+			Message: "infix: + expects numbers/strings + numbers/strings",
 		}
 
 	}
@@ -213,7 +253,7 @@ func (i NewInterpreter) Visit_List(node parser.List) (interface{}, error) {
 }
 
 func (i NewInterpreter) Visit_ValueAccess(node parser.ValueAccess) (interface{}, error) {
-	arr, err := i.visit(node.Arr)
+	value, err := i.visit(node.Arr)
 	if err != nil {
 		return nil, err
 	}
@@ -232,34 +272,49 @@ func (i NewInterpreter) Visit_ValueAccess(node parser.ValueAccess) (interface{},
 			return nil, err
 		}
 	}
-	// handle access to object properties
-	if !node.IsInterval {
-		if target, ok := arr.(map[string]interface{}); ok {
-			if k, ok := left.(string); ok {
-				if value, ok := target[k]; ok {
-					return value, nil
-				}
-				return nil, nil
+	if target, ok := value.(map[string]interface{}); ok {
+		if node.IsInterval {
+			return nil, InterpreterError{
+				Message: `infix: "[..]" expects object, array, or string`,
 			}
-			return nil, parser.SyntaxError{
-				Message: "object properties must be accessed with strings",
+		}
+		key, ok := left.(string)
+		if !ok {
+			return nil, InterpreterError{
+				Message: "object keys must be strings",
+			}
+		}
+		if result, ok := target[key]; ok {
+			return result, nil
+		}
+		return nil, nil
+	}
+	if _, ok := value.([]interface{}); !ok {
+		if _, ok := value.(string); !ok {
+			return nil, InterpreterError{
+				Message: `infix: "[..]" expects object, array, or string`,
 			}
 		}
 	}
 
-	// Check that we have integer arguments
-	A, aok := left.(float64)
-	B, bok := right.(float64)
-	if !aok || A != float64(int(A)) || (right != nil && !(bok && B == float64(int(B)))) {
-		return nil, parser.SyntaxError{
-			Message: "slicing can only be used with integer arguments",
+	startValue, startOK := left.(float64)
+	endValue, endOK := right.(float64)
+	validStart := startOK && startValue == float64(int(startValue))
+	validEnd := right == nil || endOK && endValue == float64(int(endValue))
+	if !validStart || !validEnd {
+		message := "should only use integers to access arrays or strings"
+		if node.IsInterval {
+			message = "cannot perform interval access with non-integers"
+		}
+		return nil, InterpreterError{
+			Message: message,
 		}
 	}
 
 	// Handle slicing of arrays
-	if target, ok := arr.([]interface{}); ok {
-		start := int(A)
-		end := int(B)
+	if target, ok := value.([]interface{}); ok {
+		start := int(startValue)
+		end := int(endValue)
 		if right == nil {
 			end = len(target)
 		}
@@ -283,8 +338,8 @@ func (i NewInterpreter) Visit_ValueAccess(node parser.ValueAccess) (interface{},
 		}
 		if !node.IsInterval {
 			if start >= len(target) {
-				return nil, parser.SyntaxError{
-					Message: "string index out of bounds",
+				return nil, InterpreterError{
+					Message: "index out of bounds",
 				}
 			}
 			return target[start], nil
@@ -292,10 +347,10 @@ func (i NewInterpreter) Visit_ValueAccess(node parser.ValueAccess) (interface{},
 		return target[start:end], nil
 	}
 	// Handle slicing of strings
-	if target, ok := arr.(string); ok {
+	if target, ok := value.(string); ok {
 		runeLen := utf8.RuneCountInString(target)
-		start := int(A)
-		end := int(B)
+		start := int(startValue)
+		end := int(endValue)
 		if right == nil {
 			end = runeLen
 		}
@@ -322,13 +377,18 @@ func (i NewInterpreter) Visit_ValueAccess(node parser.ValueAccess) (interface{},
 			// simply slice or index it.
 			if !node.IsInterval {
 				if start >= runeLen {
-					return nil, parser.SyntaxError{
-						Message: "string index out of bounds",
+					return nil, InterpreterError{
+						Message: "index out of bounds",
 					}
 				}
 				return string(target[start]), nil
 			}
 			return target[start:end], nil
+		}
+		if !node.IsInterval && start >= runeLen {
+			return nil, InterpreterError{
+				Message: "index out of bounds",
+			}
 		}
 		// The target contains multi-byte characters, so we must
 		// iterate over it from the beginning.
@@ -353,17 +413,15 @@ func (i NewInterpreter) Visit_ValueAccess(node parser.ValueAccess) (interface{},
 		return target[start_i:end_i], nil
 	}
 
-	return nil, parser.SyntaxError{
-		Message: "slicing can only be used on arrays and strings",
-	}
+	panic("value access target was not an array, string, or object")
 }
 
 func (i NewInterpreter) Visit_ContextValue(node parser.ContextValue) (interface{}, error) {
 	if contextValue, ok := i.context[node.Token.Value]; ok {
 		return contextValue, nil
 	}
-	return nil, parser.SyntaxError{
-		Message: fmt.Sprintf("undefined variable %s", node.Token.Value),
+	return nil, InterpreterError{
+		Message: fmt.Sprintf("unknown context value %s", node.Token.Value),
 	}
 }
 func (i NewInterpreter) Visit_FunctionCall(node parser.FunctionCall) (interface{}, error) {
@@ -387,11 +445,19 @@ func (i NewInterpreter) Visit_FunctionCall(node parser.FunctionCall) (interface{
 
 		result, err := f.Invoke(i.context, args)
 		if err != nil {
-			return nil, err
+			name := "unknown"
+			if contextValue, ok := node.Name.(parser.ContextValue); ok {
+				name = contextValue.Token.Value
+			}
+			message := fmt.Sprintf("invalid arguments to builtin: %s", name)
+			if len(args) == 0 && (name == "min" || name == "max") {
+				message += ": expected at least 1 arguments"
+			}
+			return nil, BuiltinError{Message: message}
 		}
 		return result, nil
 	}
-	return nil, parser.SyntaxError{
+	return nil, InterpreterError{
 		Message: fmt.Sprintf("%s is not callable", funcName),
 	}
 }
@@ -425,7 +491,7 @@ func mathOp(left, right interface{}, tokenKind string) (interface{}, error) {
 			return l * r, nil
 		case "/":
 			if r == 0.0 {
-				return nil, parser.SyntaxError{
+				return nil, InterpreterError{
 					Message: "division by zero",
 				}
 			}
@@ -436,8 +502,8 @@ func mathOp(left, right interface{}, tokenKind string) (interface{}, error) {
 			panic("unknown operator")
 		}
 	}
-	return nil, parser.SyntaxError{
-		Message: "expected number operands",
+	return nil, InterpreterError{
+		Message: fmt.Sprintf("infix: %s expects number %s number", tokenKind, tokenKind),
 	}
 }
 
@@ -469,8 +535,8 @@ func comparisonOp(left, right interface{}, tokenKind string) (interface{}, error
 			return l > r, nil
 		}
 	} else {
-		return nil, parser.SyntaxError{
-			Message: "comparison operator requires two strings or numbers",
+		return nil, InterpreterError{
+			Message: fmt.Sprintf("infix: %s expects numbers/strings %s numbers/strings", tokenKind, tokenKind),
 		}
 	}
 	panic(fmt.Sprintf("unknown comparison operator: '%s'", tokenKind))

--- a/internal/interpreter/parser/errors.go
+++ b/internal/interpreter/parser/errors.go
@@ -35,7 +35,7 @@ func (s SyntaxError) Error() string {
 	return fmt.Sprintf("SyntaxError%s: %s", location, message)
 }
 
-// AddLocation returns a copy of the error with a location prepended.
+// AddLocation prepends a location to the error.
 func (s SyntaxError) AddLocation(location string) error {
 	s.Location = append([]string{location}, s.Location...)
 	return s

--- a/internal/interpreter/parser/errors.go
+++ b/internal/interpreter/parser/errors.go
@@ -12,18 +12,38 @@ type SyntaxError struct {
 	Start    int
 	End      int
 	Expected []string
+	Location []string
 }
 
 func (s SyntaxError) Error() string {
-	m := s.Message
-	if m == "" {
-		m = "syntax error"
-	}
+	var message string
 	if s.Expected != nil {
-		return fmt.Sprintf("%s expected %s at %d -> '%s' in '%s'",
-			m, strings.Join(s.Expected, ", "), s.Start, s.Source[s.Start:s.End], s.Source,
-		)
+		message = fmt.Sprintf("Found: %s token, expected one of: %s",
+			s.sourceAtError(), strings.Join(s.Expected, ", "))
+	} else if s.Message == "" {
+		message = fmt.Sprintf("Unexpected input for '%s' at '%s'", s.Source, s.sourceAtError())
+	} else if s.Message == "unexpected end of input" {
+		message = "Unexpected end of input"
+	} else {
+		message = s.Message
 	}
-	return fmt.Sprintf("%s at %d -> '%s' in '%s'",
-		m, s.Start, s.Source[s.Start:s.End], s.Source)
+
+	location := ""
+	if len(s.Location) > 0 {
+		location = " at template" + strings.Join(s.Location, "")
+	}
+	return fmt.Sprintf("SyntaxError%s: %s", location, message)
+}
+
+// AddLocation returns a copy of the error with a location prepended.
+func (s SyntaxError) AddLocation(location string) error {
+	s.Location = append([]string{location}, s.Location...)
+	return s
+}
+
+func (s SyntaxError) sourceAtError() string {
+	if s.Start < 0 || s.Start > len(s.Source) || s.End < s.Start || s.End > len(s.Source) {
+		return ""
+	}
+	return s.Source[s.Start:s.End]
 }

--- a/internal/interpreter/util.go
+++ b/internal/interpreter/util.go
@@ -278,7 +278,7 @@ var contextVariablePattern = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
 func IsValidContext(context map[string]interface{}) error {
 	for k, v := range context {
 		if !contextVariablePattern.MatchString(k) {
-			return fmt.Errorf("top level keys of context must follow %s", contextVariablePattern.String())
+			return fmt.Errorf("top level keys of context must follow /[a-zA-Z_][a-zA-Z0-9_]*/")
 		}
 		if err := IsValidData(v); err != nil {
 			return err

--- a/internal/jsone.go
+++ b/internal/jsone.go
@@ -19,11 +19,7 @@ import (
 func Render(template interface{}, context map[string]interface{}) (interface{}, error) {
 	// Validate input
 	if err := i.IsValidContext(context); err != nil {
-		message := err.Error()
-		if strings.HasPrefix(message, "top level keys of context must follow") {
-			message = "top level keys of context must follow /[a-zA-Z_][a-zA-Z0-9_]*/"
-		}
-		return nil, TemplateError{Message: message}
+		return nil, TemplateError{Message: err.Error()}
 	}
 
 	// Inherit functions from builtins

--- a/internal/jsone.go
+++ b/internal/jsone.go
@@ -19,7 +19,11 @@ import (
 func Render(template interface{}, context map[string]interface{}) (interface{}, error) {
 	// Validate input
 	if err := i.IsValidContext(context); err != nil {
-		return nil, err
+		message := err.Error()
+		if strings.HasPrefix(message, "top level keys of context must follow") {
+			message = "top level keys of context must follow /[a-zA-Z_][a-zA-Z0-9_]*/"
+		}
+		return nil, TemplateError{Message: message}
 	}
 
 	// Inherit functions from builtins
@@ -61,29 +65,44 @@ type operator func(template, context map[string]interface{}) (interface{}, error
 type TemplateError struct {
 	Message  string
 	Template interface{}
+	Location []string
 }
 
 func (t TemplateError) Error() string {
-	data, _ := json.Marshal(t.Template)
-	return fmt.Sprintf("%s in template %s", t.Message, string(data))
+	location := ""
+	if len(t.Location) > 0 {
+		location = " at template" + strings.Join(t.Location, "")
+	}
+	return fmt.Sprintf("TemplateError%s: %s", location, t.Message)
+}
+
+// AddLocation returns a copy of the error with a location prepended.
+func (t TemplateError) AddLocation(location string) error {
+	t.Location = append([]string{location}, t.Location...)
+	return t
 }
 
 // restrictProperties returns an error if the template contains properties other
 // than those listed as allowed
 func restrictProperties(template map[string]interface{}, allowed ...string) error {
+	var unknown []string
 	for k := range template {
 		matched := false
 		for _, s := range allowed {
-			if s == k {
+			if s == k || regexp.MustCompile("^(?:"+s+")$").MatchString(k) {
 				matched = true
 				break
 			}
 		}
 		if !matched {
-			return TemplateError{
-				Message:  fmt.Sprintf("property '%s' is not permitted in template", k),
-				Template: template,
-			}
+			unknown = append(unknown, k)
+		}
+	}
+	if len(unknown) > 0 {
+		sort.Strings(unknown)
+		return TemplateError{
+			Message:  fmt.Sprintf("%s has undefined properties: %s", allowed[0], strings.Join(unknown, " ")),
+			Template: template,
 		}
 	}
 	return nil
@@ -345,6 +364,8 @@ var builtin = map[string]interface{}{
 var eachKeyPattern = regexp.MustCompile(`^each\(([a-zA-Z_][a-zA-Z0-9_]*)(,\s*([a-zA-Z_][a-zA-Z0-9_]*))?\)$`)
 var eachKeyAccPattern = regexp.MustCompile(`^each\(([a-zA-Z_][a-zA-Z0-9_]*),\s*([a-zA-Z_][a-zA-Z0-9_]*)(,\s*([a-zA-Z_][a-zA-Z0-9_]*))?\)$`)
 var byKeyPattern = regexp.MustCompile(`^by\(([a-zA-Z_][a-zA-Z0-9_]*)\)$`)
+var contextKeyPattern = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
+var templateIdentifierPattern = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9]*$`)
 
 var operators = map[string]operator{
 	"$eval": func(template, context map[string]interface{}) (interface{}, error) {
@@ -354,16 +375,13 @@ var operators = map[string]operator{
 		s, ok := template["$eval"].(string)
 		if !ok {
 			return nil, TemplateError{
-				Message:  "$eval expects a string expression",
+				Message:  "$eval must be given a string expression",
 				Template: template,
 			}
 		}
 		value, err := i.Parse(s, context)
 		if err != nil {
-			return nil, TemplateError{
-				Message:  err.Error(),
-				Template: template,
-			}
+			return nil, err
 		}
 		return value, nil
 	},
@@ -378,7 +396,7 @@ var operators = map[string]operator{
 		a, ok := value.([]interface{})
 		if !ok {
 			return nil, TemplateError{
-				Message:  "$flatten expects an array",
+				Message:  "$flatten value must evaluate to an array",
 				Template: template,
 			}
 		}
@@ -403,7 +421,7 @@ var operators = map[string]operator{
 		a, ok := value.([]interface{})
 		if !ok {
 			return nil, TemplateError{
-				Message:  "$flattenDeep expects an array",
+				Message:  "$flattenDeep value must evaluate to an array",
 				Template: template,
 			}
 		}
@@ -434,7 +452,7 @@ var operators = map[string]operator{
 		offset, ok := value.(string)
 		if !ok {
 			return nil, TemplateError{
-				Message:  "$fromNow expects a string value",
+				Message:  "$fromNow expects a string",
 				Template: template,
 			}
 		}
@@ -490,10 +508,7 @@ var operators = map[string]operator{
 		}
 		val, err := i.Parse(s, context)
 		if err != nil {
-			return nil, TemplateError{
-				Message:  err.Error(),
-				Template: template,
-			}
+			return nil, err
 		}
 		var result interface{}
 		if i.IsTruthy(val) {
@@ -514,6 +529,12 @@ var operators = map[string]operator{
 		if err != nil {
 			return nil, err
 		}
+		if containsFunctions(val) {
+			return nil, TemplateError{
+				Message:  "evaluated template contained uncalled functions",
+				Template: template,
+			}
+		}
 		if !i.IsJSON(val) {
 			return nil, TemplateError{
 				Message:  "$json can only stringify JSON types",
@@ -530,7 +551,7 @@ var operators = map[string]operator{
 		_, ok := template["$let"].(map[string]interface{})
 		if !ok {
 			return nil, TemplateError{
-				Message:  "$let expects an object",
+				Message:  "$let value must be an object",
 				Template: template,
 			}
 		}
@@ -551,7 +572,7 @@ var operators = map[string]operator{
 			}
 		} else {
 			return nil, TemplateError{
-				Message:  "$let expects an object",
+				Message:  "$let value must be an object",
 				Template: template,
 			}
 		}
@@ -559,19 +580,27 @@ var operators = map[string]operator{
 		in, ok := template["in"]
 		if !ok {
 			return nil, TemplateError{
-				Message:  "$let requires an 'in' clause",
+				Message:  "$let operator requires an `in` clause",
 				Template: template,
 			}
 		}
-		if err = i.IsValidContext(c); err != nil {
-			return nil, TemplateError{
-				Message:  err.Error(),
-				Template: template,
+		for key := range rv {
+			if !contextKeyPattern.MatchString(key) {
+				return nil, TemplateError{
+					Message:  "top level keys of $let must follow /[a-zA-Z_][a-zA-Z0-9_]*/",
+					Template: template,
+				}
 			}
+		}
+		if err = i.IsValidContext(c); err != nil {
+			return nil, err
 		}
 		return render(in, c)
 	},
 	"$map": func(template, context map[string]interface{}) (interface{}, error) {
+		if err := restrictProperties(template, "$map", eachKeyPattern.String()); err != nil {
+			return nil, err
+		}
 		value, err := render(template["$map"], context)
 		if err != nil {
 			return nil, err
@@ -651,7 +680,7 @@ var operators = map[string]operator{
 				R, ok := r.(map[string]interface{})
 				if !ok {
 					return nil, TemplateError{
-						Message:  fmt.Sprintf("$map on objects expects 'each(%s)' to evaluate to an object", eachIdentifier),
+						Message:  fmt.Sprintf("$map on objects expects each(%s) to evaluate to an object", eachIdentifier),
 						Template: eachTemplate,
 					}
 				}
@@ -665,12 +694,15 @@ var operators = map[string]operator{
 			return result, nil
 		default:
 			return nil, TemplateError{
-				Message:  "$map requires a value that evaluates to either an object or an array",
+				Message:  "$map value must evaluate to an array or object",
 				Template: template,
 			}
 		}
 	},
 	"$reduce": func(template, context map[string]interface{}) (interface{}, error) {
+		if err := restrictProperties(template, "$reduce", "initial", eachKeyAccPattern.String()); err != nil {
+			return nil, err
+		}
 		value, err := render(template["$reduce"], context)
 		if err != nil {
 			return nil, err
@@ -738,6 +770,9 @@ var operators = map[string]operator{
 		}
 	},
 	"$find": func(template, context map[string]interface{}) (interface{}, error) {
+		if err := restrictProperties(template, "$find", eachKeyPattern.String()); err != nil {
+			return nil, err
+		}
 		value, err := render(template["$find"], context)
 		if err != nil {
 			return nil, err
@@ -778,7 +813,7 @@ var operators = map[string]operator{
 		val, ok := value.([]interface{})
 		if !ok {
 			return nil, TemplateError{
-				Message:  "$find expects an array",
+				Message:  "$find value must evaluate to an array",
 				Template: template,
 			}
 		}
@@ -796,26 +831,20 @@ var operators = map[string]operator{
 			s, ok := eachTemplate.(string)
 			if !ok {
 				return nil, TemplateError{
-					Message:  "$find expects a string expression",
+					Message:  "each can evaluate string expressions only",
 					Template: template,
 				}
 			}
 
 			val, err := i.Parse(s, c)
 			if err != nil {
-				return nil, TemplateError{
-					Message:  err.Error(),
-					Template: template,
-				}
+				return nil, err
 			}
 
 			if i.IsTruthy(val) {
 				r, err := render(entry, c)
 				if err != nil {
-					return nil, TemplateError{
-						Message:  err.Error(),
-						Template: template,
-					}
+					return nil, err
 				}
 				return r, nil
 			}
@@ -848,20 +877,14 @@ var operators = map[string]operator{
 		for _, key := range conditions {
 			check, err := i.Parse(key, context)
 			if err != nil {
-				return nil, TemplateError{
-					Message:  err.Error(),
-					Template: template,
-				}
+				return nil, err
 			}
 
 			if i.IsTruthy(check) {
 				value := match[key]
 				r, err := render(value, context)
 				if err != nil {
-					return nil, TemplateError{
-						Message:  err.Error(),
-						Template: template,
-					}
+					return nil, err
 				}
 				result = append(result, r)
 			}
@@ -894,20 +917,14 @@ var operators = map[string]operator{
 		for _, key := range conditions {
 			check, err := i.Parse(key, context)
 			if err != nil {
-				return nil, TemplateError{
-					Message:  err.Error(),
-					Template: template,
-				}
+				return nil, err
 			}
 
 			if i.IsTruthy(check) {
 				value := match[key]
 				r, err := render(value, context)
 				if err != nil {
-					return nil, TemplateError{
-						Message:  err.Error(),
-						Template: template,
-					}
+					return nil, err
 				}
 				result = append(result, r)
 			}
@@ -924,10 +941,7 @@ var operators = map[string]operator{
 			if value, ok := match["$default"]; ok {
 				r, err := render(value, context)
 				if err != nil {
-					return nil, TemplateError{
-						Message:  err.Error(),
-						Template: template,
-					}
+					return nil, err
 				}
 				result = append(result, r)
 			}
@@ -950,7 +964,7 @@ var operators = map[string]operator{
 		a, ok := value.([]interface{})
 		if !ok {
 			return nil, TemplateError{
-				Message:  "$merge expected an array",
+				Message:  "$merge value must evaluate to an array of objects",
 				Template: template,
 			}
 		}
@@ -959,7 +973,7 @@ var operators = map[string]operator{
 			obj, ok := entry.(map[string]interface{})
 			if !ok {
 				return nil, TemplateError{
-					Message:  "$merge expected an array of objects",
+					Message:  "$merge value must evaluate to an array of objects",
 					Template: template,
 				}
 			}
@@ -980,7 +994,7 @@ var operators = map[string]operator{
 		a, ok := value.([]interface{})
 		if !ok {
 			return nil, TemplateError{
-				Message:  "$mergeDeep expected an array",
+				Message:  "$mergeDeep value must evaluate to an array of objects",
 				Template: template,
 			}
 		}
@@ -1014,7 +1028,7 @@ var operators = map[string]operator{
 			obj, ok := entry.(map[string]interface{})
 			if !ok {
 				return nil, TemplateError{
-					Message:  "$mergeDeep expected an array of objects",
+					Message:  "$mergeDeep value must evaluate to an array of objects",
 					Template: template,
 				}
 			}
@@ -1033,7 +1047,7 @@ var operators = map[string]operator{
 		a, ok := value.([]interface{})
 		if !ok {
 			return nil, TemplateError{
-				Message:  "$reverse expected a value that evaluated to an array",
+				Message:  "$reverse value must evaluate to an array of objects",
 				Template: template,
 			}
 		}
@@ -1044,6 +1058,9 @@ var operators = map[string]operator{
 		return result, nil
 	},
 	"$sort": func(template, context map[string]interface{}) (interface{}, error) {
+		if err := restrictProperties(template, "$sort", byKeyPattern.String()); err != nil {
+			return nil, err
+		}
 		value, err := render(template["$sort"], context)
 		if err != nil {
 			return nil, err
@@ -1051,7 +1068,7 @@ var operators = map[string]operator{
 		items, ok := value.([]interface{})
 		if !ok {
 			return nil, TemplateError{
-				Message:  "$sort expects a value that evaluates to an array",
+				Message:  "$sorted values to be sorted must have the same type",
 				Template: template,
 			}
 		}
@@ -1101,10 +1118,7 @@ var operators = map[string]operator{
 				c[byIdentifier] = item
 				val, err := i.Parse(byExpr, c)
 				if err != nil {
-					return nil, TemplateError{
-						Message:  err.Error(),
-						Template: template,
-					}
+					return nil, err
 				}
 				byValues[j] = val
 			}
@@ -1132,13 +1146,13 @@ var operators = map[string]operator{
 			}
 		default:
 			return nil, TemplateError{
-				Message:  "$sort can only operate on strings and numbers, add a 'by(identifier)' to sort by a key",
+				Message:  "$sorted values to be sorted must have the same type",
 				Template: template,
 			}
 		}
 		if mixedTypes {
 			return nil, TemplateError{
-				Message:  "$sort cannot handle mixed types, tweak the 'by(identifier)' property to conform values",
+				Message:  "$sorted values to be sorted must have the same type",
 				Template: template,
 			}
 		}
@@ -1196,6 +1210,7 @@ func interpolate(template string, context map[string]interface{}) (string, error
 			if err != nil {
 				return "", err
 			}
+			expression := remaining[offset+2 : end-1]
 			remaining = remaining[end:]
 			switch v := value.(type) {
 			case string:
@@ -1207,7 +1222,9 @@ func interpolate(template string, context map[string]interface{}) (string, error
 			case nil:
 				// null, interpolates as empty string
 			default:
-				return "", fmt.Errorf("cannot interpolate array/object in '%s'", template)
+				return "", TemplateError{
+					Message: fmt.Sprintf("interpolation of '%s' produced an array or object", expression),
+				}
 			}
 		} else {
 			result += "${"
@@ -1251,6 +1268,25 @@ func containsFunctions(rendered interface{}) bool {
 	}
 }
 
+type locationError interface {
+	AddLocation(string) error
+}
+
+func addErrorLocation(err error, location string) error {
+	if err, ok := err.(locationError); ok {
+		return err.AddLocation(location)
+	}
+	return err
+}
+
+func templateKeyLocation(key string) string {
+	if templateIdentifierPattern.MatchString(key) {
+		return "." + key
+	}
+	data, _ := json.Marshal(key)
+	return "[" + string(data) + "]"
+}
+
 func render(template interface{}, context map[string]interface{}) (interface{}, error) {
 	if template == nil {
 		return nil, nil
@@ -1262,10 +1298,10 @@ func render(template interface{}, context map[string]interface{}) (interface{}, 
 		return interpolate(v, context)
 	case []interface{}:
 		result := make([]interface{}, 0, len(v))
-		for _, val := range v {
+		for index, val := range v {
 			r, err := render(val, context)
 			if err != nil {
-				return nil, err
+				return nil, addErrorLocation(err, fmt.Sprintf("[%d]", index))
 			}
 			if r != deleteMarker {
 				result = append(result, r)
@@ -1293,19 +1329,19 @@ func render(template interface{}, context map[string]interface{}) (interface{}, 
 
 		// Clone object
 		result := make(map[string]interface{}, len(v))
-		for k, v := range v {
+		for k, value := range v {
 
-			r, err := render(v, context)
+			r, err := render(value, context)
 			if err != nil {
-				return nil, err
+				return nil, addErrorLocation(err, templateKeyLocation(k))
 			}
 			if r != deleteMarker {
 				if strings.HasPrefix(k, "$$") {
 					k = k[1:]
 				} else if reservedIdentifiers.MatchString(k) {
 					return nil, TemplateError{
-						Message:  fmt.Sprintf("'$%s' is reserved used '$$%s' instead", k, k),
-						Template: v,
+						Message:  "$<identifier> is reserved; use $$<identifier>",
+						Template: value,
 					}
 				}
 				k, err = interpolate(k, context)

--- a/internal/jsone_test.go
+++ b/internal/jsone_test.go
@@ -36,7 +36,11 @@ func (c *testCase) Test(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, c.Result, result, "expected a different result")
 	} else {
-		require.Error(t, err)
+		if message, ok := c.Error.(string); ok {
+			require.EqualError(t, err, message)
+		} else {
+			require.Error(t, err)
+		}
 	}
 }
 

--- a/py/jsone/newsfragments/393.bugfix
+++ b/py/jsone/newsfragments/393.bugfix
@@ -1,0 +1,1 @@
+The Go implementation now enforces the spec error messages: the specification test suite asserts the exact expected message string, and TemplateError/InterpreterError/BuiltinError/SyntaxError output is aligned with specification.yml to match the Python implementation.


### PR DESCRIPTION
In the Go implementation, `internal/jsone_test.go` loaded `specification.yml` and, for cases with an `error:` property, only asserted that *some* error occurred (`require.Error`), ignoring the expected message string. The Python harness already asserts the message exactly, so the spec strings are the canonical cross-language error messages.

This makes the Go spec test enforce the message: when a case's `error` is a string, `testCase.Test` now uses `require.EqualError(t, err, expected)` (keeping plain `require.Error` for `error: true`). It then brings the Go error messages into line with the spec: `TemplateError.Error()` renders the `TemplateError: <message>` form, the individual `TemplateError` and builtin messages (`BuiltinError: invalid arguments to builtin: <name>`) are aligned in `internal/jsone.go` and `internal/interpreter/interpreter.go`, interpreter messages in `internal/interpreter/execute.go` match the `InterpreterError: ...` forms, and `SyntaxError.Error()` in `internal/interpreter/parser/errors.go` matches the `SyntaxError: ...` format. All changes are string-level and fully specified by `specification.yml`.

# Checklist

Before submitting a pull request, please check the following:

* [x] All tests pass for you on your machine for all implementations (all implementations must behave identically)
* [x] New tests have been added for any new functionality or to prevent regressions of a bugfix
* [x] Added a short description of the change to `newsfragments/393.bugfix`

Fixes #393
