### PR TITLE
Add negative array index boundary tests

### DIFF
--- a/py/jsone/newsfragments/556.bugfix
+++ b/py/jsone/newsfragments/556.bugfix
@@ -1,0 +1,1 @@
+Added conformance tests for array indexes equal to the negative array length.

--- a/specification.yml
+++ b/specification.yml
@@ -2711,6 +2711,16 @@ context: {a: [1,2,3,4]}
 template: {$eval: 'a[-2]'}
 result: 3
 ---
+title: array access at negative length
+context: {a: [1,2,3,4,5]}
+template: {$eval: 'a[-5]'}
+result: 1
+---
+title: array access at negative length (single item)
+context: {a: [1]}
+template: {$eval: 'a[-1]'}
+result: 1
+---
 title:    array access [index expression]
 context:  {a: [10,11,12], b: 1}
 template: {$eval: 'a[b]'}


### PR DESCRIPTION
## Summary

- add the requested shared-spec case for a five-item array indexed at `-5`
- add the singleton `-1` boundary case
- add the required issue-numbered news fragment

Closes #556.

## Verification

- `cd js && yarn test` (1178 passing)
- `cd js && yarn rollup`
- `python -m pytest -q py/test` (1195 passed)
- `python -m black --check py`
- `go test ./...`
- `go vet ./...`
- `cargo test --manifest-path rs/Cargo.toml` (118 unit and 1169 specification tests passed)
- `git diff --check`

## Baseline notes

`cargo fmt --check` and strict Clippy report pre-existing findings in unchanged Rust source; both reproduce identically on untouched `main@d3db5b7`.

# Checklist

- [x] All tests pass for you on your machine for all implementations (all implementations must behave identically)
- [x] New tests have been added for any new functionality or to prevent regressions of a bugfix
- [x] Added a short description of the change to `newsfragments/556.bugfix`
