### PR TITLE
javascript impl: refactor to use dicts rather than objects

### DIFF
--- a/js/src/builtins.js
+++ b/js/src/builtins.js
@@ -3,7 +3,7 @@ var fromNow = require('./from-now');
 var {
   isString, isNumber, isBool,
   isInteger, isArray, isObject,
-  isNull, isFunction,
+  isNull, isFunction, hasOwn, mergeContext,
 } = require('./type-utils');
 
 let types = {
@@ -174,8 +174,8 @@ module.exports = (context) => {
   define('defined', builtins, {
     argumentTests: ['string'],
     needsContext: true,
-    invoke: (ctx, str) => ctx.hasOwnProperty(str)
+    invoke: (ctx, str) => hasOwn(ctx, str)
   });
 
-  return Object.assign({}, builtins, context);
+  return mergeContext(builtins, context);
 };

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -1,5 +1,3 @@
-/* eslint-disable */
-
 const {Parser} = require('./parser');
 const Tokenizer = require("../src/tokenizer");
 const {Interpreter} = require('./interpreter');
@@ -9,9 +7,27 @@ var {
   isString, isNumber, isBool,
   isArray, isObject,
   isTruthy, isFunction,
+  hasOwn, mergeContext,
 } = require('./type-utils');
 var addBuiltins = require('./builtins');
 var {JSONTemplateError, TemplateError, SyntaxError} = require('./error');
+
+let setProp = (obj, key, value) => {
+  Object.defineProperty(obj, key, {
+    value, writable: true, enumerable: true, configurable: true,
+  });
+  return obj;
+};
+
+let mergeObjects = (...sources) => {
+  let result = {};
+  for (let source of sources) {
+    for (let key of Object.keys(source)) {
+      setProp(result, key, source[key]);
+    }
+  }
+  return result;
+};
 
 let syntaxRuleError = (token) => {
     return new SyntaxError(`Found: ${token.value} token, expected one of: !=, &&, (, *, **, +, -, ., /, <, <=, ==, >, >=, [, in, ||`);
@@ -125,14 +141,14 @@ operators.$if = (template, context) => {
     throw new TemplateError('$if can evaluate string expressions only');
   }
   if (isTruthy(parse(template['$if'], context))) {
-    if(template.hasOwnProperty('$then')){
+    if(hasOwn(template, '$then')){
       throw new TemplateError('$if Syntax error: $then: should be spelled then: (no $)')
     }
 
-   return template.hasOwnProperty('then') ? render(template.then, context) : deleteMarker;
+   return hasOwn(template, 'then') ? render(template.then, context) : deleteMarker;
   }
 
-  return template.hasOwnProperty('else') ? render(template.else, context) : deleteMarker;
+  return hasOwn(template, 'else') ? render(template.else, context) : deleteMarker;
 };
 
 operators.$json = (template, context) => {
@@ -151,7 +167,7 @@ operators.$let = (template, context) => {
   if (!isObject(template['$let'])) {
     throw new TemplateError('$let value must be an object');
   }
-  let variables = {};
+  let variables = Object.create(null);
 
   let initialResult = render(template['$let'], context);
   if (!isObject(initialResult)) {
@@ -165,7 +181,7 @@ operators.$let = (template, context) => {
     }
   });
 
-  var child_context = Object.assign({}, context, variables);
+  var child_context = mergeContext(context, variables);
 
   if (template.in == undefined) {
     throw new TemplateError('$let operator requires an `in` clause');
@@ -203,18 +219,17 @@ operators.$map = (template, context) => {
     let eachValue;
     value = value.map(v => {
       let args = typeof i !== 'undefined' ? {[x]: v.val, [i]: v.key} : {[x]: v};
-      eachValue = render(each, Object.assign({}, context, args));
+      eachValue = render(each, mergeContext(context, args));
       if (!isObject(eachValue)) {
         throw new TemplateError(`$map on objects expects each(${x}) to evaluate to an object`);
       }
       return eachValue;
     }).filter(v => v !== deleteMarker);
-    //return value.reduce((a, o) => Object.assign(a, o), {});
-    return Object.assign({}, ...value);
+    return mergeObjects(...value);
   } else {
     return value.map((v, idx) => {
       let args = typeof i !== 'undefined' ? {[x]: v, [i]: idx} : {[x]: v};
-      return render(each, Object.assign({}, context, args));
+      return render(each, mergeContext(context, args));
     }).filter(v => v !== deleteMarker);
   }
 };
@@ -245,7 +260,7 @@ operators.$reduce = (template, context) => {
 
   return value.reduce((acc, v, idx)=>{
     const args = typeof i !== 'undefined' ? {[a]: acc, [x]: v, [i]: idx} : {[a]: acc, [x]: v};
-    const r = render(each, Object.assign({}, context, args));
+    const r = render(each, mergeContext(context, args));
     return r === deleteMarker ? acc : r;
   }, initialValue);
 };
@@ -279,8 +294,8 @@ operators.$find = (template, context) => {
   const result = value.find((v, idx) => {
     let args = typeof i !== 'undefined' ? {[x]: v, [i]: idx} : {[x]: v};
 
-    if (isTruthy(parse(each, Object.assign({}, context, args)))) {
-      return render(each, Object.assign({}, context, args));
+    if (isTruthy(parse(each, mergeContext(context, args)))) {
+      return render(each, mergeContext(context, args));
     }
   });
 
@@ -326,7 +341,7 @@ operators.$switch = (template, context) => {
     throw new TemplateError('$switch can only have one truthy condition');
   }
 
-  if (result.length === 0 && "$default" in conditions) {
+  if (result.length === 0 && hasOwn(conditions, '$default')) {
     result.push(render(conditions[ '$default' ], context));
   }
 
@@ -342,7 +357,7 @@ operators.$merge = (template, context) => {
     throw new TemplateError('$merge value must evaluate to an array of objects');
   }
 
-  return Object.assign({}, ...value);
+  return mergeObjects(...value);
 };
 
 operators.$mergeDeep = (template, context) => {
@@ -364,13 +379,9 @@ operators.$mergeDeep = (template, context) => {
       return l.concat(r);
     }
     if (isObject(l) && isObject(r)) {
-      let res = Object.assign({}, l);
-      for (let p in r) { // eslint-disable-line taskcluster/no-for-in
-        if (p in l) {
-          res[p] = merge(l[p], r[p]);
-        } else {
-          res[p] = r[p];
-        }
+      let res = mergeObjects(l);
+      for (let p of Object.keys(r)) {
+        setProp(res, p, hasOwn(l, p) ? merge(l[p], r[p]) : r[p]);
       }
       return res;
     }
@@ -403,7 +414,7 @@ operators.$sort = (template, context) => {
   let match = /^by\(([a-zA-Z_][a-zA-Z0-9_]*)\)$/.exec(byKey);
   let by;
   if (match) {
-    let contextClone = Object.assign({}, context);
+    let contextClone = mergeContext(context);
     let x = match[1];
     let byExpr = template[byKey];
     by = value => {
@@ -462,7 +473,7 @@ let render = (template, context) => {
     }).filter((v) => v !== deleteMarker);
   }
 
-  let matches = Object.keys(operators).filter(c => template.hasOwnProperty(c));
+  let matches = Object.keys(operators).filter(c => hasOwn(template, c));
   if (matches.length > 1) {
     throw new TemplateError('only one operator allowed');
   }
@@ -495,7 +506,7 @@ let render = (template, context) => {
         key = interpolate(key, context);
       }
 
-      result[key] = value;
+      setProp(result, key, value);
     }
   }
   return result;
@@ -575,7 +586,7 @@ module.exports = (template, context = {}) => {
   if (!test) {
     throw new TemplateError('top level keys of context must follow /[a-zA-Z_][a-zA-Z0-9_]*/');
   }
-  context = addBuiltins(Object.assign({}, {now: fromNow('0 seconds')}, context));
+  context = addBuiltins(mergeContext({now: fromNow('0 seconds')}, context));
   let result = render(template, context);
   if (result === deleteMarker) {
     return null;

--- a/js/src/interpreter.js
+++ b/js/src/interpreter.js
@@ -1,4 +1,4 @@
-const {isFunction, isObject, isString, isArray, isNumber, isInteger, isTruthy} = require("../src/type-utils");
+const {isFunction, isObject, isString, isArray, isNumber, isInteger, isTruthy, hasOwn} = require("../src/type-utils");
 const {InterpreterError} = require('./error');
 
 let expectationError = (operator, expectation) => new InterpreterError(`${operator} expects ${expectation}`);
@@ -101,7 +101,7 @@ class Interpreter {
                 return Math.pow(right, left);
             case ("."): {
                 if (isObject(left)) {
-                    if (left.hasOwnProperty(right)) {
+                    if (hasOwn(left, right)) {
                         return left[right];
                     }
                     throw new InterpreterError(`object has no property "${right}"`);
@@ -204,7 +204,7 @@ class Interpreter {
             throw new InterpreterError('object keys must be strings');
         }
 
-        if (array.hasOwnProperty(left)) {
+        if (hasOwn(array, left)) {
             return array[left];
         } else {
             return null;
@@ -212,7 +212,7 @@ class Interpreter {
     }
 
     visit_ContextValue(node) {
-        if (this.context.hasOwnProperty(node.token.value)) {
+        if (hasOwn(this.context, node.token.value)) {
             let contextValue = this.context[node.token.value];
             return contextValue
         }
@@ -227,7 +227,7 @@ class Interpreter {
             node.args.forEach(function (item) {
                 args.push(this.visit(item))
             }, this);
-            if (funcName.hasOwnProperty("jsone_builtin")) {
+            if (hasOwn(funcName, "jsone_builtin")) {
                 args.unshift(this.context);
             }
             return funcName.apply(null, args);

--- a/js/src/type-utils.js
+++ b/js/src/type-utils.js
@@ -1,4 +1,8 @@
 let utils = {
+  // avoids redefinition
+  hasOwn: (obj, prop) => Object.prototype.hasOwnProperty.call(obj, prop),
+  // use null prototype so `__proto__` key behaves
+  mergeContext: (...sources) => Object.assign(Object.create(null), ...sources),
   isString:   expr => typeof expr === 'string',
   isNumber:   expr => typeof expr === 'number',
   isInteger:  expr => typeof expr === 'number' && Number.isInteger(expr),

--- a/js/test/misc_test.js
+++ b/js/test/misc_test.js
@@ -51,4 +51,100 @@ suite('misc', function() {
     let my_builtin = () => 42;
     assume(jsone({$eval: 'my_builtin()'}, {my_builtin})).eql(42);
   });
+
+  test('by(__proto__) cannot be used to look up unrelated identifiers like constructor', function() {
+    let func = () => "foobar";
+
+    let template = {
+      $let: {"hasOwn${'Property'}": {$eval: 'func'}},
+      in: {
+        $sort: [{$eval: 'func'}],
+        "by(__proto__)": 'constructor("return 42")()',
+      },
+    };
+
+    assume(() => jsone(template, {func})).throws(/unknown context value constructor/);
+  });
+
+  test('identifier lookup ignores a context value named hasOwnProperty', function() {
+    let func = () => "foobar";
+
+    assume(() => jsone({$eval: 'constructor'}, {hasOwnProperty: func}))
+      .throws(/unknown context value constructor/);
+    assume(() => jsone({$eval: 'toString'}, {hasOwnProperty: func}))
+      .throws(/unknown context value toString/);
+  });
+
+  test('by(__proto__) does not affect state outside the sort', function() {
+    jsone({$sort: [{a: 1}, {a: 2}], 'by(__proto__)': '__proto__.a'}, {});
+
+    assume(({}).a).equals(undefined);
+    assume(Object.prototype.a).equals(undefined);
+  });
+
+  test('interpolated __proto__ result key is an ordinary property', function() {
+    let result = jsone({"__pro${e}to__": {$eval: '1 + 1'}}, {e: ''});
+
+    assume(Object.prototype.hasOwnProperty.call(result, '__proto__')).equals(true);
+    assume(result.__proto__).equals(2);
+    assume(Object.getPrototypeOf(result)).equals(Object.prototype);
+  });
+
+  test('the defined builtin only sees real context keys', function() {
+    let func = () => "foobar";
+    assume(jsone({$eval: 'defined("constructor")'}, {hasOwnProperty: func})).equals(false);
+  });
+
+  test('each(__proto__) cannot be used to look up unrelated identifiers like constructor', function() {
+    let func = () => "foobar";
+
+    let template = {
+      $let: {"hasOwn${'Property'}": {$eval: 'func'}},
+      in: {
+        $map: [{$eval: 'func'}],
+        "each(__proto__)": {$eval: 'constructor("return 42")()'},
+      },
+    };
+
+    assume(() => jsone(template, {func})).throws(/unknown context value constructor/);
+  });
+
+  test('__proto__ as an each() binding behaves like any other identifier', function() {
+    assume(jsone({$map: [1, 2, 3], 'each(__proto__)': {$eval: '__proto__ + 1'}}, {})).eql([2, 3, 4]);
+    assume(jsone(
+      {$reduce: [1, 2, 3], initial: 0, 'each(a, __proto__)': {$eval: 'a + __proto__'}}, {},
+    )).equals(6);
+    assume(jsone({$find: [1, 2, 3], 'each(__proto__)': '__proto__ > 1'}, {})).equals(2);
+
+    assume(({}).a).equals(undefined);
+    assume(Object.prototype.a).equals(undefined);
+  });
+
+  test('__proto__ as a by() binding behaves like any other identifier', function() {
+    assume(jsone({$sort: [3, 1, 2], 'by(__proto__)': '__proto__'}, {})).eql([1, 2, 3]);
+  });
+
+  test('__proto__ as a $let variable name is an ordinary binding', function() {
+    let template = JSON.parse('{"$let": {"__proto__": 5}, "in": {"$eval": "__proto__ + 1"}}');
+    assume(jsone(template, {})).equals(6);
+  });
+
+  test('$merge preserves a literal __proto__ key without touching the real prototype', function() {
+    let template = JSON.parse('{"$merge": [{"__proto__": 1}, {"a": 2}]}');
+    let result = jsone(template, {});
+
+    assume(Object.keys(result).sort()).eql(['__proto__', 'a']);
+    assume(result.__proto__).equals(1);
+    assume(result.a).equals(2);
+    assume(Object.getPrototypeOf(result)).equals(Object.prototype);
+  });
+
+  test('$mergeDeep preserves a literal __proto__ key without touching the real prototype', function() {
+    let template = JSON.parse('{"$mergeDeep": [{"__proto__": {"x": 1}}, {"__proto__": {"y": 2}}]}');
+    let result = jsone(template, {});
+
+    assume(Object.keys(result)).eql(['__proto__']);
+    assume(result.__proto__).eql({x: 1, y: 2});
+    assume(Object.getPrototypeOf(result)).equals(Object.prototype);
+  });
 });

--- a/py/jsone/newsfragments/589.bugfix
+++ b/py/jsone/newsfragments/589.bugfix
@@ -1,0 +1,1 @@
+Fixed the JS implementation to treat contexts and template objects as explicit key/value dictionaries rather than JavaScript objects.

--- a/specification.yml
+++ b/specification.yml
@@ -122,6 +122,11 @@ context:  {nothing: null}
 template: 'big pile of ${nothing}'
 result:   'big pile of '
 ---
+title:    interpolated __proto__ key
+context:  {e: ''}
+template: {'__pro${e}to__': {$eval: '1 + 1'}}
+result:   {'__proto__': 2}
+---
 title: invalid context
 context: {'a b c': 1}
 template: {}
@@ -1621,6 +1626,11 @@ title: merge with undefined properties
 template: {$merge: [{a: 1}, {b: 2, c: 3}, {d: 4}], foo: "bar", bing: "baz"}
 context: {}
 error: 'TemplateError: $merge has undefined properties: bing foo'
+---
+title:    merge preserves a literal __proto__ key
+context:  {}
+template: {$merge: [{'__proto__': 1}, {a: 2}]}
+result:   {'__proto__': 1, a: 2}
 ################################################################################
 ---
 section:  $mergeDeep
@@ -1689,6 +1699,16 @@ title: mergeDeep with undefined properties
 template: {$mergeDeep: [{a: {x: 1,'y': 2}}, {a: {'y': 3, z: 4}}], foo: "bar", bing: "baz"}
 context: {}
 error: 'TemplateError: $mergeDeep has undefined properties: bing foo'
+---
+title:    mergeDeep preserves a literal __proto__ key
+context:  {}
+template: {$mergeDeep: [{'__proto__': 1}, {a: 2}]}
+result:   {'__proto__': 1, a: 2}
+---
+title:    mergeDeep preserves a literal __proto__ key when merging nested objects
+context:  {}
+template: {$mergeDeep: [{'__proto__': {x: 1}}, {'__proto__': {y: 2}}]}
+result:   {'__proto__': {x: 1, y: 2}}
 ################################################################################
 ---
 section:  $sort


### PR DESCRIPTION
Treat contexts and template objects as explicit key/value dictionaries