### PR TITLE
Treat object literals as explicit dicts and not objects

### DIFF
--- a/js/src/index.js
+++ b/js/src/index.js
@@ -7,17 +7,10 @@ var {
   isString, isNumber, isBool,
   isArray, isObject,
   isTruthy, isFunction,
-  hasOwn, mergeContext,
+  hasOwn, mergeContext, setProp,
 } = require('./type-utils');
 var addBuiltins = require('./builtins');
 var {JSONTemplateError, TemplateError, SyntaxError} = require('./error');
-
-let setProp = (obj, key, value) => {
-  Object.defineProperty(obj, key, {
-    value, writable: true, enumerable: true, configurable: true,
-  });
-  return obj;
-};
 
 let mergeObjects = (...sources) => {
   let result = {};

--- a/js/src/interpreter.js
+++ b/js/src/interpreter.js
@@ -1,4 +1,4 @@
-const {isFunction, isObject, isString, isArray, isNumber, isInteger, isTruthy, hasOwn} = require("../src/type-utils");
+const {isFunction, isObject, isString, isArray, isNumber, isInteger, isTruthy, hasOwn, setProp} = require("../src/type-utils");
 const {InterpreterError} = require('./error');
 
 let expectationError = (operator, expectation) => new InterpreterError(`${operator} expects ${expectation}`);
@@ -239,8 +239,8 @@ class Interpreter {
     visit_Object(node) {
         let obj = {};
 
-        for (let key in node.obj) {
-            obj[key] = this.visit(node.obj[key])
+        for (let key of Object.keys(node.obj)) {
+            setProp(obj, key, this.visit(node.obj[key]));
         }
 
         return obj

--- a/js/src/parser.js
+++ b/js/src/parser.js
@@ -1,5 +1,6 @@
 const {UnaryOp, BinOp, Primitive, ContextValue, FunctionCall, ValueAccess, List, Object} = require("../src/AST");
 const {SyntaxError} = require('./error');
+const {setProp} = require('./type-utils');
 
 let syntaxRuleError = (token, expects) => {
     expects.sort();
@@ -217,7 +218,7 @@ class Parser {
             if (value == null) {
                 throw syntaxRuleError(this.current_token, this.expectedTokens);
             }
-            obj[key] = value;
+            setProp(obj, key, value);
             if (this.current_token != null && this.current_token.kind == "}") {
                 break;
             } else {

--- a/js/src/type-utils.js
+++ b/js/src/type-utils.js
@@ -3,6 +3,12 @@ let utils = {
   hasOwn: (obj, prop) => Object.prototype.hasOwnProperty.call(obj, prop),
   // use null prototype so `__proto__` key behaves
   mergeContext: (...sources) => Object.assign(Object.create(null), ...sources),
+  setProp: (obj, key, value) => {
+    Object.defineProperty(obj, key, {
+      value, writable: true, enumerable: true, configurable: true,
+    });
+    return obj;
+  },
   isString:   expr => typeof expr === 'string',
   isNumber:   expr => typeof expr === 'number',
   isInteger:  expr => typeof expr === 'number' && Number.isInteger(expr),

--- a/js/test/misc_test.js
+++ b/js/test/misc_test.js
@@ -139,6 +139,17 @@ suite('misc', function() {
     assume(Object.getPrototypeOf(result)).equals(Object.prototype);
   });
 
+  test('__proto__ in an expression object literal is an ordinary key', function() {
+    for (let expr of ['{"__proto__": 1, "a": 2}', '{__proto__: 1, a: 2}']) {
+      let result = jsone({$eval: expr}, {});
+
+      assume(Object.keys(result)).eql(['__proto__', 'a']);
+      assume(result.__proto__).equals(1);
+      assume(result.a).equals(2);
+      assume(Object.getPrototypeOf(result)).equals(Object.prototype);
+    }
+  });
+
   test('$mergeDeep preserves a literal __proto__ key without touching the real prototype', function() {
     let template = JSON.parse('{"$mergeDeep": [{"__proto__": {"x": 1}}, {"__proto__": {"y": 2}}]}');
     let result = jsone(template, {});

--- a/specification.yml
+++ b/specification.yml
@@ -6003,6 +6003,16 @@ title: 'parse object (12)'
 context: {key: 1}
 template: {$eval: '{a: key, b: key + 1'}
 error: true
+---
+title: 'parse literal object with a __proto__ key'
+context: {key: 1}
+template: {$eval: '{"__proto__": key, "a": key + 1}'}
+result: {'__proto__': 1, a: 2}
+---
+title: 'parse object with a bar __proto__ literal key'
+context: {key: 1}
+template: {$eval: '{__proto__: key, a: key + 1}'}
+result: {'__proto__': 1, a: 2}
 ################################################################################
 ---
 section: expression language - errors


### PR DESCRIPTION
This is a followup to d2bd496f4c8ab814e08fc25aebbb777c9bd92140 which missed that object literals had the same problem
