### PR TITLE
Validate release packaging in CI and fix python packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,9 +99,10 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
+      # Keep in sync with the version in .taskcluster.yml
       - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
-          python-version: '3.12'
+          python-version: '3.11'
       - name: Build sdist and wheel
         run: |
           set -euo pipefail
@@ -151,7 +152,11 @@ jobs:
           persist-credentials: false
       - name: Stage specification.yml into the crate
         run: ./scripts/stage-crate-spec.sh
-      - run: cargo --version && rustc --version
+      # ubuntu-latest's preinstalled Rust can lag behind whatever the
+      # runner image last baked in; update to track stable the same way
+      # .taskcluster.yml's rust:latest tasks do, rather than relying on
+      # an implicit, undated snapshot.
+      - run: rustup update stable && rustup default stable && cargo --version && rustc --version
       - name: cargo publish --dry-run
         working-directory: rs
         run: cargo publish --dry-run --allow-dirty
@@ -281,6 +286,10 @@ jobs:
       - name: Stage specification.yml into the crate
         if: steps.pre.outputs.skip == 'false'
         run: ./scripts/stage-crate-spec.sh
+      # See the equivalent step in build-crates for why this runs.
+      - name: Update to latest stable Rust
+        if: steps.pre.outputs.skip == 'false'
+        run: rustup update stable && rustup default stable
       - uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
         if: steps.pre.outputs.skip == 'false'
         id: auth

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -40,7 +40,8 @@ tasks:
                 git checkout ${repo.ref} &&
                 cd js &&
                 yarn &&
-                yarn test
+                yarn test &&
+                ./package-test.sh
         - $map: 
           - {env: py38, vers: "3.8"}
           - {env: py39, vers: "3.9"}
@@ -59,8 +60,10 @@ tasks:
                 git config advice.detachedHead false &&
                 git checkout ${repo.ref} &&
                 cd py/ &&
-                pip install tox &&
-                tox -e ${v.env}
+                pip install tox build twine &&
+                tox -e ${v.env} &&
+                python -m build &&
+                twine check --strict dist/*
         # This image generally tracks the latest Go
         - image: 'golangci/golangci-lint'
           name: Go tests (and lint)
@@ -94,7 +97,11 @@ tasks:
                 git config advice.detachedHead false &&
                 git checkout ${repo.ref} &&
                 cd rs/ &&
-                cargo test
+                cargo test &&
+                cd .. &&
+                ./scripts/stage-crate-spec.sh &&
+                cd rs &&
+                cargo publish --dry-run --allow-dirty
         # Always use the latest Rust for the mdbook tests
         - image: 'rust:latest'
           name: MdBook tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,61 +1,49 @@
-Jsone 4.8.3 (2026-08-20)
-========================
+# Jsone 4.8.3 (2026-08-20)
 
-Features
---------
+## Features
 
 - Release script now checks that the local main branch is in sync with upstream, that the release tag does not already exist on the remote, and that the version has not already been published to npm, PyPI, or crates.io. (#577)
 
 
-Bugfixes
---------
+## Bugfixes
 
 - The Go implementation now enforces the spec error messages: the specification test suite asserts the exact expected message string, and TemplateError/InterpreterError/BuiltinError/SyntaxError output is aligned with specification.yml to match the Python implementation. (#393)
 - Added conformance tests for array indexes equal to the negative array length. (#556)
 - Fixed the JS implementation to treat contexts and template objects as explicit key/value dictionaries rather than JavaScript objects. (#589)
 
 
-Jsone 4.8.2 (2026-02-26)
-========================
+# Jsone 4.8.2 (2026-02-26)
 
 No significant changes.
 
 
-Jsone 4.8.1 (2026-01-23)
-========================
+# Jsone 4.8.1 (2026-01-23)
 
-Bugfixes
---------
+## Bugfixes
 
 - Fix handling of false-y $default values in $switch in JS and Go implementations. (#541)
 - The Rust version no longer panics when it encounters a non-finite float. (#555)
 - The Rust error message when a non finite number is encountered now properly includes the non finite value, rather than {value}. (#558)
 
 
-Jsone 4.8.0 (2024-10-03)
-========================
+# Jsone 4.8.0 (2024-10-03)
 
-Features
---------
+## Features
 
 - Introduces the `$reduce` operator which combines an array or object into a single value. (#531)
 - Introduced the `range(..)` function for generating ranges of integers. (#534)
 
 
-Jsone 4.7.1 (2024-07-05)
-========================
+# Jsone 4.7.1 (2024-07-05)
 
-Bugfixes
---------
+## Bugfixes
 
 - Removed unnecessary print statement from rust implementation. (slice_print)
 
 
-Jsone 4.7.0 (2024-02-17)
-========================
+# Jsone 4.7.0 (2024-02-17)
 
-Features
---------
+## Features
 
 - WrapFunction has been added to the external interface of the Golang module so
   users can inject custom functions into the context. (#523)
@@ -64,111 +52,91 @@ Features
   either `null` or if used within an object or array, omitted from the parent object. (#525)
 
 
-Bugfixes
---------
+## Bugfixes
 
 - Support for Unicode strings has been improved and made consistent across implementations: all indexing and slicing is in terms of codepoints, rather than bytes. (#390)
 - Division by zero is now considered an error, since the result is not representible in JSON. (#391)
 
 
-Jsone 4.6.0 (2023-11-21)
-========================
+# Jsone 4.6.0 (2023-11-21)
 
-Bugfixes
---------
+## Bugfixes
 
 - For JavaScript, variables added in a `$let` do not persist outside of that `$let` any more. (#473)
 - The context is required to be a JSON object in all implementations. (#481)
 - Python versions older than 3.8 are no longer tested or supported. Notably, Python 2 is no longer supported. (#486)
 
 
-Improved Documentation
-----------------------
+## Improved Documentation
 
 - All of the time-range abbreviations supported by `fromNow` and `$fromNow` are
   now documented, and all implementations agree on those abbreviations. (#483)
 
 
-Jsone 4.5.3 (2023-07-27)
-========================
+# Jsone 4.5.3 (2023-07-27)
 
-Bugfixes
---------
+## Bugfixes
 
 - Upgraded Rust parser-builder `nom` to major version 7. (#462)
 - Fix Rust JSON conversions for floats of small magnitude (#466)
 
 
-Jsone 4.5.2 (2023-04-10)
-========================
+# Jsone 4.5.2 (2023-04-10)
 
-Bugfixes
---------
+## Bugfixes
 
 - Fixed a bug that caused some examples in documentation not to be rendered on json-e.js.org (#461)
 
 
-Jsone 4.5.1 (2023-03-20)
-========================
+# Jsone 4.5.1 (2023-03-20)
 
 - The Rust crate no longer rebuilds on every invocation. (#460)
 
 
-Jsone 4.5.0 (2022-12-25)
-========================
+# Jsone 4.5.0 (2022-12-25)
 
-Features
---------
+## Features
 
 - Added a $default case to the switch operator (#455)
 
 
-Jsone 4.4.3 (2021-11-17)
-========================
+# Jsone 4.4.3 (2021-11-17)
 
-Features
---------
+## Features
 
 - The JSON-e GitHub repository has been moved to https://github.com/json-e/json-e. (#430)
 
 
-Bugfixes
---------
+## Bugfixes
 
 - Emit an error on uncalled functions in all implementations. (#158)
 - All implementations now enforce that context is an object.  This was always the intent, but the JS and Python implementations' validation was not particularly thorough. (#408)
 
 
-Jsone 4.4.1 (2021-03-12)
-========================
+# Jsone 4.4.1 (2021-03-12)
 
 No significant changes.
 
 This version updates the release mechanics to include descriptions for each package.
 
 
-Jsone 4.4.0 (2021-03-12)
-========================
+# Jsone 4.4.0 (2021-03-12)
 
-Features
---------
+## Features
 
 - JSON-e is now also available as a Rust crate! (#289)
 - Each implementation language is now in its own subdirectory.  This change should not affect users of the library. (#401)
 
 
-Bugfixes
---------
+## Bugfixes
 
 - Syntax errors regarding unexpected identifiers are now phrased more clearly (Python and JS implementations only) (#383)
 - JS implementation now throws instances of the correct SyntaxError type (#399)
 
 
-Jsone 4.3.0 (2020-08-27)
-========================
+# Jsone 4.3.0 (2020-08-27)
 
-Features
---------
+## Features
 
 - Introduces `split` to built-in string functions enabling string splitting with a delimiter. 
   Input and delimiter can either be `string` or `number`. (#368)
@@ -176,19 +144,15 @@ Features
 - The Go port now uses GoModules.  It should nonetheless remain compatible with earlier versions of Go. (#373)
 
 
-Jsone 4.2.0 (2020-07-17)
-========================
+# Jsone 4.2.0 (2020-07-17)
 
-Bugfixes
---------
+## Bugfixes
 
 - The Python implementation no longer causes warnings about invalid escape sequences (#361).
 
-Jsone 4.1.0 (2020-05-29)
-========================
+# Jsone 4.1.0 (2020-05-29)
 
-Features
---------
+## Features
 
 - Introduces $switch operator, which behaves like a combination of the $if and $match operator for
   more complex boolean logic. It gets an object, in which every key is a string expression(s), where
@@ -196,40 +160,33 @@ Features
   the value corresponding to the key that were evaluated to true. (#257)
 
 
-Bugfixes
---------
+## Bugfixes
 
 - Builtin functions are now called with relevant context.
   This means that builtins like `fromNow()` and `defined()` respect variables defined via `$let`. (342&343)
 - Fix error (constructor.name) when using with Webpack in production mode (#354)
 
 
-Improved Documentation
-----------------------
+## Improved Documentation
 
 - The `defined()` builtin is now documented. (#341)
 - Tests now include a test case for #354, regarding function evaluation. (#354)
 
 
-Jsone 4.0.1 (2020-03-11)
-========================
+# Jsone 4.0.1 (2020-03-11)
 
-Bugfixes
---------
+## Bugfixes
 
 - Revert PR # 330 (fix for issue 158)
 
-Improved Documentation
-----------------------
+## Improved Documentation
 
 - Update releasing documentation with information on how to release on npm and deploy the web-site (release)
 
 
-Jsone 4.0.0 (2020-03-04)
-===================
+# Jsone 4.0.0 (2020-03-04)
 
-Bugfixes
---------
+## Bugfixes
 
 - Added support for the short-circuiting of the boolean logic operators || and &&
   Separated parser and interpreter.
@@ -237,11 +194,9 @@ Bugfixes
   Interpreter make tree traversal. (#244)
 
 
-Jsone 3.0.2 (2020-03-03)
-========================
+# Jsone 3.0.2 (2020-03-03)
 
-Bugfixes
---------
+## Bugfixes
 
 - ## Part fix for #168: Enforce all error messages match
 
@@ -295,27 +250,22 @@ Bugfixes
 - Strings containing unicode are now handled correctly by str() on Python 2. (#338)
 
 
-Improved Documentation
-----------------------
+## Improved Documentation
 
 - Fix typo in CONTRIBUTING.md (contributingmd)
 - Clarify 'all tests pass' instruction in PULL_REQUEST_TEMPLATE.md (pull_request_template)
 - The `$fromNow` builtin is tested to properly handle a new value of `now` defined in a `$let`. (#344)
 
 
-Jsone 3.0.1 (2018-07-11)
-========================
+# Jsone 3.0.1 (2018-07-11)
 
-Features
---------
+## Features
 
 - Introduction of support of TypeScript typings. This version adds type for the jsone function.
 
-Jsone 3.0.0 (2018-11-01)
-========================
+# Jsone 3.0.0 (2018-11-01)
 
-Features
---------
+## Features
 
 - Support of `index` or `key` context variable in `$map` operation.
 
@@ -335,8 +285,7 @@ Features
 - Add support for element indexes in $map (#242)
 
 
-Bugfixes
---------
+## Bugfixes
 
 - [BREAKING] make typeof(null) be "null", not null
 
@@ -344,48 +293,39 @@ Bugfixes
   However, it is unlikely to affect most uses of JSON-e. (#246)
 
 
-Jsone 2.7.1 (2018-09-22)
-========================
+# Jsone 2.7.1 (2018-09-22)
 
-Bugfixes
---------
+## Bugfixes
 
 - Ensure that `$match` results are deterministic (#258)
 
 
-Jsone 2.7.0 (2018-08-23)
-========================
+# Jsone 2.7.0 (2018-08-23)
 
-Features
---------
+## Features
 
 - Add new operator `$match` which allows for a new way of flow control by evaluating boolean expressions it is given. (#161)
 
 
-Jsone 2.6.0 (2018-06-20)
-========================
+# Jsone 2.6.0 (2018-06-20)
 
-Features
---------
+## Features
 
 - Begin using towncrier to build CHANGELOG.rst (#193)
 - Add a `number` builtin that converts strings to numbers (#240)
 
 
-Bugfixes
---------
+## Bugfixes
 
 - Ensure that ``$json`` consistently sorts object properties across languages
   (#222)
 
 
-Improved Documentation
-----------------------
+## Improved Documentation
 
 - Link to rjsone in README (#238)
 
 
-Older Versions
-==============
+# Older Versions
 
 For versions of JSON-e 2.5.0 and older, please consult the git history.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,8 +108,8 @@ yarn rollup
 When making a pull request with your changes, create a new file in
 `newsfragments/` named after the issue or bug you are working on, with a suffix
 of `.bugfix`, `.feature`, or (for docs-only changes) `.doc`.  The content of
-this file should be in reStructuredText format. Keep it to a simple sentence,
-and you should be fine!
+this file should be in Markdown format, the same as this file. Keep it to a
+simple sentence, and you should be fine!
 
 For example, `newsfragments/201.bugfix` might contain `Fixed the precedence of
 the || and 'in' operators`.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ See [json-e.js.org](https://json-e.js.org).
 ## Changes
 
 See
-[CHANGELOG.rst](https://github.com/json-e/json-e/blob/main/CHANGELOG.rst)
+[CHANGELOG.md](https://github.com/json-e/json-e/blob/main/CHANGELOG.md)
 for the changes in each version of this library.
 
 ## In Action

--- a/py/jsone/newsfragments/592.bugfix
+++ b/py/jsone/newsfragments/592.bugfix
@@ -1,0 +1,1 @@
+Fixed missing PyPI package metadata (long_description_content_type) that caused the release of 4.8.3 to fail at the packaging step, and added packaging dry-run checks to CI so problems like this are caught on every push rather than only when a release is attempted.

--- a/py/setup.py
+++ b/py/setup.py
@@ -19,6 +19,7 @@ setup(
     version=version,
     description=description,
     long_description=long_description,
+    long_description_content_type="text/x-rst",
     author="Dustin J. Mitchell",
     url="https://json-e.js.org",
     author_email="dustin@mozilla.com",

--- a/py/setup.py
+++ b/py/setup.py
@@ -19,7 +19,7 @@ setup(
     version=version,
     description=description,
     long_description=long_description,
-    long_description_content_type="text/x-rst",
+    long_description_content_type="text/markdown",
     author="Dustin J. Mitchell",
     url="https://json-e.js.org",
     author_email="dustin@mozilla.com",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
 [tool.towncrier]
     package = "jsone"
     package_dir = "py"
-    filename = "CHANGELOG.rst"
+    filename = "CHANGELOG.md"

--- a/release.sh
+++ b/release.sh
@@ -220,15 +220,15 @@ preflight() {
 
 update_changelog() {
     local cl_version
-    cl_version=$(head -n 1 CHANGELOG.rst | cut -d' ' -f 2)
+    cl_version=$(sed -n 's/^# Jsone \([0-9.]*\) .*/\1/p' CHANGELOG.md | head -1)
     if [ "${cl_version}" == "${version}" ]; then
-        echo "=== CHANGELOG.rst already at ${version}, skipping towncrier"
+        echo "=== CHANGELOG.md already at ${version}, skipping towncrier"
         return
     fi
     echo "=== Changelog draft"
     towncrier build --version="${version}" --draft
     read -r -p "Look OK? (ctrl-c if not, enter if OK) "
-    towncrier build --version="${version}" --yes   # stages CHANGELOG.rst, removes fragments
+    towncrier build --version="${version}" --yes   # stages CHANGELOG.md, removes fragments
 }
 
 update_versions() {

--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -66,13 +66,13 @@ else
     printf '  ok        %-16s %s (no /vN suffix required below v2)\n' "go.mod" "${modpath}"
 fi
 
-# CHANGELOG heading shape: `Jsone X.Y.Z (YYYY-MM-DD)`
-cl_first_line="$(head -n1 CHANGELOG.rst)"
-if echo "${cl_first_line}" | grep -Eq "^Jsone ${version//./\\.} \([0-9]{4}-[0-9]{2}-[0-9]{2}\)\$"; then
-    printf '  ok        %-16s %s\n' "CHANGELOG.rst" "${version}"
+# CHANGELOG heading shape: `# Jsone X.Y.Z (YYYY-MM-DD)`
+cl_first_line="$(head -n1 CHANGELOG.md)"
+if echo "${cl_first_line}" | grep -Eq "^# Jsone ${version//./\\.} \([0-9]{4}-[0-9]{2}-[0-9]{2}\)\$"; then
+    printf '  ok        %-16s %s\n' "CHANGELOG.md" "${version}"
 else
-    printf '  MISMATCH  %-16s expected first line '"'"'Jsone %s (YYYY-MM-DD)'"'"', found: %s\n' \
-        "CHANGELOG.rst" "${version}" "${cl_first_line}"
+    printf '  MISMATCH  %-16s expected first line '"'"'# Jsone %s (YYYY-MM-DD)'"'"', found: %s\n' \
+        "CHANGELOG.md" "${version}" "${cl_first_line}"
     fail=1
 fi
 


### PR DESCRIPTION
Release 4.8.3 of python library failed due to missing `long_description_content_type`.

This fixes the issue, but also switches the python changelog from reStructuredText to (Github Flavored) Markdown to align with what we use for the rest of the docs (and .md seems like a nicer standard than .rst).